### PR TITLE
Readme skeuomorph example compiles and uses printSchema variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,12 @@ val definition = """
 val schema: Schema = new Schema.Parser().parse(definition)
 
 val parseAvro: Schema => Mu[FreesF] =
-  scheme.hylo(transformAvro[Mu[FreesF]].algebra.run, fromAvro.run)
+  scheme.hylo(transformAvro[Mu[FreesF]].algebra, fromAvro)
 val printSchema: Mu[FreesF] => String =
   scheme.cata(render)
 
 (parseAvro >>> print)(schema)
+(printSchema >>> print)(parseAvro(schema))
 ```
 
 


### PR DESCRIPTION
Based on the type signature for `hylo` I think the example should not call `.run` directly. Also the `printSchema` variable wasn't used in the example so I added a print out for that. (The change on line 122 is just IntelliJ adding newlines at the end of files that don't have it. Sorry bout the noise!)