### PR TITLE
Add some more tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq(scalaVersion.value, "2.11.12"),
   ThisBuild / scalacOptions -= "-Xplugin-require:macroparadise",
   libraryDependencies ++= Seq(
+    %%("cats-laws") % Test,
     %%("cats-core"),
     "io.higherkindness" %% "droste-core"   % "0.5.0",
     "io.higherkindness" %% "droste-macros" % "0.5.0",

--- a/src/test/scala/PrinterSpec.scala
+++ b/src/test/scala/PrinterSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package skeuomorph
+
+import org.typelevel.discipline.specs2.Discipline
+import cats.laws.discipline.ContravariantMonoidalTests
+import cats.laws.discipline.eq._
+
+import cats.kernel.Eq
+import cats.instances.string._
+
+import org.specs2._
+import org.scalacheck._
+
+class PrinterSpec extends Specification with ScalaCheck with Discipline {
+
+  implicit def printerArbitrary[T: Cogen]: Arbitrary[Printer[T]] =
+    Arbitrary(implicitly[Arbitrary[T => String]].arbitrary.map(Printer.apply))
+
+  implicit def printerEq[T: Arbitrary]: Eq[Printer[T]] =
+    Eq.by[Printer[T], T => String](_.print)
+
+  def is = s2"""
+  A pretty printer
+
+  $contravariantMonoidalPrinter
+  """
+
+  val contravariantMonoidalPrinter = checkAll(
+    "ContravariantMonoidal[Printer].contravariantMonoidal",
+    ContravariantMonoidalTests[Printer].contravariantMonoidal[Int, Int, Int])
+
+}

--- a/src/test/scala/PrinterSpec.scala
+++ b/src/test/scala/PrinterSpec.scala
@@ -41,7 +41,11 @@ class PrinterSpec extends Specification with ScalaCheck with Discipline {
 
   def is = s2"""
   $contravariantMonoidalPrinter
+
+
   $monoidPrinter
+
+
   $semigroupPrinter
   """
 

--- a/src/test/scala/PrinterSpec.scala
+++ b/src/test/scala/PrinterSpec.scala
@@ -17,9 +17,12 @@
 package skeuomorph
 
 import org.typelevel.discipline.specs2.Discipline
+import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.ContravariantMonoidalTests
 import cats.laws.discipline.eq._
 
+import cats.ContravariantSemigroupal
+import cats.ContravariantMonoidal
 import cats.kernel.Eq
 import cats.instances.string._
 
@@ -33,15 +36,20 @@ class PrinterSpec extends Specification with ScalaCheck with Discipline {
 
   implicit def printerEq[T: Arbitrary]: Eq[Printer[T]] =
     Eq.by[Printer[T], T => String](_.print)
+  implicit val printerMonoid    = ContravariantMonoidal.monoid[Printer, Int]
+  implicit val printerSemigroup = ContravariantSemigroupal.semigroup[Printer, Int]
 
   def is = s2"""
-  A pretty printer
-
   $contravariantMonoidalPrinter
+  $monoidPrinter
+  $semigroupPrinter
   """
 
   val contravariantMonoidalPrinter = checkAll(
     "ContravariantMonoidal[Printer].contravariantMonoidal",
     ContravariantMonoidalTests[Printer].contravariantMonoidal[Int, Int, Int])
+
+  val monoidPrinter    = checkAll("ContravariantMonoidal[Printer].monoid", MonoidTests[Printer[Int]].monoid)
+  val semigroupPrinter = checkAll("ContravariantSemigroupal[Printer].semigroup", SemigroupTests[Printer[Int]].semigroup)
 
 }


### PR DESCRIPTION
Check that the `Printer` instance for `ContravariantMonoidal`, `Monoid`, and `Semigroup` are lawful