### PR TITLE
Propagates imports instead of cloning dependent messages

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -107,8 +107,8 @@ object print {
    * Needed to be able to use the DependentImport case class
    * as a [[cats.ContravariantMonoidal]].
    */
-  def importTuple[T](i: DependentImport[T]): (String, T) = i match {
-    case DependentImport(pkg, tpe) => (pkg, tpe)
+  def importTuple[T](i: DependentImport[T]): (String, String, T) = i match {
+    case DependentImport(pkg, name, tpe) => (pkg, name, tpe)
   }
 
   /**
@@ -166,6 +166,7 @@ object print {
   def depImport[T](implicit T: Basis[MuF, T]): Printer[DependentImport[T]] =
     (
       konst("import ") *< string,
+      konst(".") *< string,
       konst(".") *< Printer(namedTypes[T] >>> schema.print)
     ).contramapN(importTuple)
 

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -50,7 +50,7 @@ object print {
       case TContaining(values)       => values.mkString("\n")
       case TRequired(value)          => value
       case TCoproduct(invariants) =>
-        invariants.toList.mkString("Cop[", " :: ", ":: TNil]")
+        invariants.toList.mkString("Cop[", " :: ", " :: TNil]")
       case TSum(name, fields) =>
         val printFields = fields.map(f => s"case object $f extends $name").mkString("\n  ")
         s"""
@@ -73,10 +73,10 @@ object print {
    */
   def protoTuple[T](
       proto: Protocol[T]
-  ): (Option[String], List[(String, String)], String, List[T], List[Service[T]]) =
+  ): (Option[String], List[(String, String)], List[DependentImport[T]], String, List[T], List[Service[T]]) =
     proto match {
-      case Protocol(name, pkg, options, declarations, services) =>
-        (pkg, options, name, declarations, services)
+      case Protocol(name, pkg, options, declarations, services, imports) =>
+        (pkg, options, imports, name, declarations, services)
     }
 
   /**
@@ -102,6 +102,14 @@ object print {
       case Service(name, serType, ops) =>
         (serType, name, ops)
     }
+
+  /**
+   * Needed to be able to use the DependentImport case class
+   * as a [[cats.ContravariantMonoidal]].
+   */
+  def importTuple[T](i: DependentImport[T]): (String, T) = i match {
+    case DependentImport(pkg, tpe) => (pkg, tpe)
+  }
 
   /**
    * needed to use SerializationType as a [[catz.contrib.Decidable]].
@@ -155,6 +163,12 @@ object print {
       sepBy(operation, "\n") >* newLine >* konst("}")
     ).contramapN(serviceTuple)
 
+  def depImport[T](implicit T: Basis[MuF, T]): Printer[DependentImport[T]] =
+    (
+      konst("import ") *< string,
+      konst(".") *< Printer(namedTypes[T] >>> schema.print)
+    ).contramapN(importTuple)
+
   def option: Printer[(String, String)] =
     (konst("@option(name = ") *< string) >*< (konst(", value = ") *< string >* konst(")"))
 
@@ -164,6 +178,7 @@ object print {
     (
       konst("package ") *< optional(string) >* newLine >* newLine,
       sepBy(option, lineFeed),
+      sepBy(depImport, lineFeed) >* newLine >* newLine,
       konst("object ") *< string >* konst(" { ") >* newLine >* newLine,
       sepBy(schema, lineFeed) >* newLine,
       sepBy(service, doubleLineFeed) >* (newLine >* newLine >* konst("}"))

--- a/src/main/scala/higherkindness/skeuomorph/mu/protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/protocol.scala
@@ -78,7 +78,7 @@ object Protocol {
       )
 
     val toImports: DependentImport[T] => DependentImport[U] =
-      imp => DependentImport(imp.pkg, toMu(imp.tpe))
+      imp => DependentImport(imp.pkg, imp.protocol, toMu(imp.tpe))
 
     new Protocol[U](
       name = protocol.name,
@@ -100,4 +100,4 @@ object Service {
   final case class Operation[T](name: String, request: OperationType[T], response: OperationType[T])
 }
 
-final case class DependentImport[T](pkg: String, tpe: T)
+final case class DependentImport[T](pkg: String, protocol: String, tpe: T)

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -112,7 +112,8 @@ object ParseProto {
 
   def getDependentImports[A](dependent: FileDescriptorProto, files: List[FileDescriptorProto])(
       implicit A: Embed[ProtobufF, A]): List[DependentImport[A]] =
-    dependent.getMessageTypeList.j2s.map(d => DependentImport(dependent.getPackage, toMessage(d, files)))
+    dependent.getMessageTypeList.j2s.map(d =>
+      DependentImport(dependent.getPackage, formatName(dependent.getName), toMessage(d, files)))
 
   def formatName(name: String): String = name.replace(".proto", "")
 

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -29,6 +29,7 @@ import higherkindness.skeuomorph.FileUtils._
 import higherkindness.skeuomorph.{Parser, _}
 import java.util
 
+import higherkindness.skeuomorph.mu.DependentImport
 import qq.droste._
 import qq.droste.syntax.embed._
 
@@ -87,9 +88,9 @@ object ParseProto {
   )(implicit A: Embed[ProtobufF, A]): Protocol[A] =
     findDescriptorProto(descriptorFileName, files)
       .map { file =>
-        val dependents: List[A] = file.getDependencyList.j2s
-          .flatMap(findDescriptorProto(_, files))
-          .flatMap(getDependentValues(_, files))
+        val imports: List[DependentImport[A]] = file.getDependencyList.j2s
+          .flatMap(b => findDescriptorProto(b, files))
+          .flatMap(f => getDependentImports(f, files))
 
         val messages: List[A] = file.getMessageTypeList.j2s.map(d => toMessage[A](d, files))
 
@@ -99,8 +100,9 @@ object ParseProto {
           formatName(file.getName),
           file.getPackage,
           Nil,
-          dependents ++ messages ++ enums,
-          file.getServiceList.j2s.map(s => toService[A](s, files))
+          messages ++ enums,
+          file.getServiceList.j2s.map(s => toService[A](s, files)),
+          imports
         )
       }
       .getOrElse(throw ProtobufNativeException(s"Could not find descriptors for: $descriptorFileName"))
@@ -108,10 +110,9 @@ object ParseProto {
   def findDescriptorProto(name: String, files: List[FileDescriptorProto]): Option[FileDescriptorProto] =
     files.find(_.getName == name)
 
-  def getDependentValues[A](dependent: FileDescriptorProto, files: List[FileDescriptorProto])(
-      implicit A: Embed[ProtobufF, A]): List[A] =
-    dependent.getMessageTypeList.j2s.map(d => toMessage(d, files)) ++
-      dependent.getEnumTypeList.j2s.map(toEnum(_)(A))
+  def getDependentImports[A](dependent: FileDescriptorProto, files: List[FileDescriptorProto])(
+      implicit A: Embed[ProtobufF, A]): List[DependentImport[A]] =
+    dependent.getMessageTypeList.j2s.map(d => DependentImport(dependent.getPackage, toMessage(d, files)))
 
   def formatName(name: String): String = name.replace(".proto", "")
 

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/Protocol.scala
@@ -15,13 +15,15 @@
  */
 
 package higherkindness.skeuomorph.protobuf
+import higherkindness.skeuomorph.mu.DependentImport
 
 final case class Protocol[T](
     name: String,
     pkg: String,
     options: List[(String, String)],
     declarations: List[T],
-    services: List[Protocol.Service[T]]
+    services: List[Protocol.Service[T]],
+    imports: List[DependentImport[T]]
 )
 
 object Protocol {
@@ -38,28 +40,5 @@ object Protocol {
       response: T,
       responseStreaming: Boolean
   )
-  // def fromProto[T](protocol: Protocol)(implicit T: Embed[ProtobufF, T]): Protocol[T] = {
-  //   val toProtobufF: NativeDescriptor => T = scheme.ana(fromProtobuf)
-
-  //   def toService(s: NativeService): Service[T] =
-  //     Service[T](s.name, s.operations.map(toOperation))
-
-  //   def toOperation(o: NativeOperation): Operation[T] =
-  //     Operation[T](
-  //       name = o.name,
-  //       request = toProtobufF(o.request),
-  //       requestStreaming = o.requestStreaming,
-  //       response = toProtobufF(o.response),
-  //       responseStreaming = o.responseStreaming
-  //     )
-
-  //   Protocol[T](
-  //     name = protocol.name,
-  //     pkg = protocol.`package`,
-  //     options = Nil,
-  //     declarations = protocol.values.map(m => toProtobufF(m)),
-  //     services = protocol.services.map(s => toService(s))
-  //   )
-  // }
 
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -59,7 +59,7 @@ class ProtobufProtocolSpec extends Specification {
   val expectation =
     """package com.acme
       |
-      |import com.acme.Author
+      |import com.acme.author.Author
       |
       |object book {
       |

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -57,11 +57,12 @@ class ProtobufProtocolSpec extends Specification {
   }
 
   val expectation =
-    """package com.book
+    """package com.acme
+      |
+      |import com.acme.Author
       |
       |object book {
       |
-      |@message final case class Author(name: String, nick: String)
       |@message final case class Book(isbn: Long, title: String, author: List[Author], binding_type: BindingType)
       |@message final case class GetBookRequest(isbn: Long)
       |@message final case class GetBookViaAuthor(author: Author)

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/author.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/author.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.book;
+package com.acme;
 
 message Author {
     string name = 1;

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/book.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-package com.book;
+package com.acme;
 
 import "author.proto";
 


### PR DESCRIPTION
This PR closes #74 

In summary:

If we have `author.proto`:

```proto
package com.acme;

message Author {
    string name = 1;
    string nick = 2;
}
```

and a `book.proto`:

```proto
package com.acme;

import "author.proto";

message Book {
    int64 isbn = 1;
    string title = 2;
    repeated Author author = 3;
}
```

If we try to produce the scala code given the `book.proto`

## What we had previously

We are generating code like this:

```scala
package com.acme

object book {
  @message final case class Author(name: String, nick: String)
  @message final case class Book(isbn: Long, title: String, author: List[Author])
}
```

## What we have now

We are generating code like this:

```scala
package com.acme

import com.acme.author.Author

object book {
  @message final case class Book(isbn: Long, title: String, author: List[Author])
}
```


