### PR TITLE
Ff/print multiple responses

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -28,8 +28,8 @@ import qq.droste._
 object print {
   import schema._
 
-  def openApi[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[(PackageName, OpenApi[T])] =
-    (imports >* newLine, impl[T]).contramapN {
+  def impl[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[(PackageName, OpenApi[T])] =
+    (imports >* newLine, implDefinition[T]).contramapN {
       case (packageName, openApi) =>
         (
           packages ++ List(
@@ -39,7 +39,7 @@ object print {
           openApi)
     }
 
-  def impl[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[OpenApi[T]] =
+  def implDefinition[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[OpenApi[T]] =
     (
       konst("object ") *< show[ImplName] >* konst(" {") *< newLine,
       sepBy(twoSpaces *< (circeEncoder >|< circeDecoder), "\n") >* newLine,

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -127,7 +127,7 @@ object print {
           status,
           responseTpe,
           (
-            tpe,
+            defaultResponseErrorName(operationId, none),
             anonymousType.fold[Either[String, Unit]](if (tpe === responseTpe) ().asRight else tpe.asLeft)(_ =>
               ().asRight),
             n))
@@ -140,7 +140,7 @@ object print {
       .contramapN {
         case (operationId, (x, n)) =>
           val (tpe, innerTpe, _) = defaultTypesAndSchemas(operationId, x)
-          (innerTpe, (tpe, tpe, n))
+          (innerTpe, (defaultResponseErrorName(operationId, none), tpe, n))
       }
 
   def responseImpl[T: Basis[JsonSchemaF, ?]]: Printer[(OperationId, String, (Either[Response[T], Reference], Int))] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -226,10 +226,7 @@ object print {
 
   private val packages = List(
     "cats.effect._",
-    "cats.syntax.functor._",
-    "cats.syntax.either._",
-    "cats.syntax.show._",
-    "cats.implicits.catsStdShowForLong",
+    "cats.implicits._",
     "org.http4s._",
     "org.http4s.client.Client",
     "org.http4s.client.blaze._",

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -122,10 +122,15 @@ object print {
       konst(".map(x => ") *< coproductIf(string >* konst("(x)") >|< konst("x")) >* konst(".asLeft)")).contramapN {
       case (operationId, status, (r, n)) =>
         val (tpe, anonymousType, _) = statusTypesAndSchemas[T](operationId, r)
+        val responseTpe             = anonymousType.getOrElse(responseOrType.print(r))
         (
           status,
-          anonymousType.getOrElse(responseOrType.print(r)),
-          (tpe, anonymousType.fold[Either[String, Unit]](tpe.asLeft)(_ => ().asRight), n))
+          responseTpe,
+          (
+            tpe,
+            anonymousType.fold[Either[String, Unit]](if (tpe === responseTpe) ().asRight else tpe.asLeft)(_ =>
+              ().asRight),
+            n))
     }
 
   def defaultResponseImpl[T: Basis[JsonSchemaF, ?]]: Printer[(OperationId, (Either[Response[T], Reference], Int))] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -261,7 +261,7 @@ object print {
         )(space)
 
       def withBody: Printer[String] =
-        konst(".withBody(") *< string >* konst(")")
+        konst(".withEntity(") *< string >* konst(")")
     }
   }
   object v18 {
@@ -276,7 +276,7 @@ object print {
         )(space)
 
       def withBody: Printer[String] =
-        konst(".withEntity(") *< string >* konst(")")
+        konst(".withBody(") *< string >* konst(")")
     }
   }
 }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -121,15 +121,9 @@ object print {
     implicit val packageNameShow: Show[PackageName] = Show.show(_.value)
   }
 
-  final case class EncoderName(value: String) extends AnyVal
-  object EncoderName {
-    implicit val encoderNameShow: Show[EncoderName] = Show.show(_.value)
-  }
+  final case class Encoder[T](value: Var[T]) extends AnyVal
 
-  final case class DecoderName(value: String) extends AnyVal
-  object DecoderName {
-    implicit val decoderNameShow: Show[DecoderName] = Show.show(_.value)
-  }
+  final case class Decoder[T](value: Var[T]) extends AnyVal
 
   final case class OperationId(value: String) extends AnyVal
 

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -315,7 +315,9 @@ object print {
       konst("  type ") *< string >* konst(" = "),
       sepBy(string, " :+: "),
       (konst(" :+: CNil") >|< unit)
-    ).contramapN(x => (x._1, x._2, x._3, if (x._3.size > 1) ().asLeft else ().asRight))
+    ).contramapN {
+      case (schemas, tpe, errorTypes) => (schemas, tpe, errorTypes, if (errorTypes.size > 1) ().asLeft else ().asRight)
+    }
 
   private def responsesSchema[T: Basis[JsonSchemaF, ?]]: Printer[
     (String, Map[String, Either[Response[T], Reference]])] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -410,7 +410,7 @@ object print {
     (List("models._", "shapeless.{:+:, CNil}").map(PackageName.apply), a, b, c, d)
   }
 
-  def operations[T: Basis[JsonSchemaF, ?]]: Printer[OpenApi[T]] =
+  def interfaceDefinition[T: Basis[JsonSchemaF, ?]]: Printer[OpenApi[T]] =
     (
       imports >* newLine,
       konst("trait ") *< show[TraitName] >* konst("[F[_]] {") >* newLine,

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -255,7 +255,7 @@ object print {
       tpe: String)(success: => (String, List[String])): (String, Option[String], List[String]) = {
     val innerType = s"${operationId.fold("")(_.show.capitalize)}${normalize(response.description).capitalize}"
     val newSchema =
-      typeFromResponse(response).map(schema(innerType.some).print).getOrElse("")
+      typeFromResponse(response).map(schema(innerType.some).print).getOrElse("Unit")
     tpe match {
       case _ if (tpe === newSchema) =>
         un(second(success) { x =>

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -397,17 +397,20 @@ object print {
   def toOperationsWithPath[T](x: (TraitName, Map[String, ItemObject[T]])): (TraitName, List[OperationWithPath[T]]) =
     second(x)(_.toList.flatMap(itemObjectTuple[T]))
 
-  private def operationsTuple[T: Basis[JsonSchemaF, ?]](x: (TraitName, Map[String, ItemObject[T]])): (
+  private def operationsTuple[T: Basis[JsonSchemaF, ?]](openApi: OpenApi[T]): (
       List[PackageName],
       TraitName,
       TraitName,
       List[OperationWithPath[T]],
       (TraitName, List[OperationWithPath[T]])) = {
-    val (a, b, c, d) = un(second(duplicate(toOperationsWithPath(x))) { case (a, b) => (a, (x._1, b)) })
+    val traitName = TraitName(openApi)
+    val (a, b, c, d) = un(second(duplicate(toOperationsWithPath(traitName -> openApi.paths))) {
+      case (a, b) => (a, (traitName, b))
+    })
     (List("models._", "shapeless.{:+:, CNil}").map(PackageName.apply), a, b, c, d)
   }
 
-  def operations[T: Basis[JsonSchemaF, ?]]: Printer[(TraitName, Map[String, ItemObject[T]])] =
+  def operations[T: Basis[JsonSchemaF, ?]]: Printer[OpenApi[T]] =
     (
       imports >* newLine,
       konst("trait ") *< show[TraitName] >* konst("[F[_]] {") >* newLine,

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -193,8 +193,8 @@ object print {
   private def defaultRequestName[T](operationId: OperationId): String =
     s"${operationId.show}Request".capitalize
 
-  private def defaultResponseName[T](operationId: OperationId): String =
-    s"${operationId.show}Response".capitalize
+  private def defaultResponseErrorName[T](operationId: OperationId): String =
+    s"${operationId.show}Error".capitalize
 
   private def typeFromResponse[T: Basis[JsonSchemaF, ?]](response: Response[T]): Option[T] =
     response.content.get(jsonMediaType).flatMap(_.schema)
@@ -217,7 +217,7 @@ object print {
 
   def responsesTypes[T: Basis[JsonSchemaF, ?]]: Printer[ResponsesWithOperationId[T]] = Printer {
     case (x, y) =>
-      val defaultName = defaultResponseName(x)
+      val defaultName = defaultResponseErrorName(x)
       y.size match {
         case 0 => "Unit"
         case 1 => responseOrType.print(y.head._2)
@@ -274,7 +274,7 @@ object print {
               if (successStatusCode(code))
                 tpe -> Nil
               else {
-                val newTpe = defaultResponseName(OperationId.from(response.description))
+                val newTpe = defaultResponseErrorName(OperationId.from(response.description))
                 newTpe -> List(newCaseClass(newTpe, "value" -> tpe))
               }
           }
@@ -340,8 +340,8 @@ object print {
       .contramapN { x =>
         un(second(x)(_.map { x =>
           val operationId = OperationId(x)
-          (operationId                        -> x._3.requestBody) ->
-            (defaultResponseName(operationId) -> x._3.responses)
+          (operationId                             -> x._3.requestBody) ->
+            (defaultResponseErrorName(operationId) -> x._3.responses)
         }.unzip))
       }
 

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -81,6 +81,15 @@ object print {
     scheme.cata(algebra).apply(t)
   }
 
+  def isArray[T: Basis[JsonSchemaF, ?]](t: T): Boolean = {
+    import JsonSchemaF._
+    val algebra: Algebra[JsonSchemaF, Boolean] = Algebra {
+      case ArrayF(_) => true
+      case _         => false
+    }
+    scheme.cata(algebra).apply(t)
+  }
+
   def schemaPair[T: Basis[JsonSchemaF, ?]]: Printer[(String, T)] = Printer {
     case (name, tpe) =>
       if (isBasic(tpe)) s"type $name = ${schema().print(tpe)}" else schema(name.some).print(tpe)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -25,7 +25,7 @@ import cats.implicits._
 import qq.droste._
 
 object print {
-  import higherkindness.skeuomorph.openapi.schema.Components
+  import higherkindness.skeuomorph.openapi.schema.OpenApi
 
   val componentsRegex = """#/components/schemas/(.+)""".r
 
@@ -86,9 +86,9 @@ object print {
       if (isBasic(tpe)) s"type $name = ${schema().print(tpe)}" else schema(name.some).print(tpe)
   }
 
-  def model[T: Basis[JsonSchemaF, ?]]: Printer[Components[T]] =
+  def model[T: Basis[JsonSchemaF, ?]]: Printer[OpenApi[T]] =
     (
       (konst("object models {") >* newLine >* space >* space) *< sepBy(schemaPair, "\n  ") >* (newLine >* konst("}"))
-    ).contramap(_.schemas.toList)
+    ).contramap(_.components.toList.flatMap(_.schemas))
 
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -135,12 +135,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def getPayload(id: String): F[Either[GetPayloadResponse, Payload]]
+           |  def getPayload(id: String): F[Either[GetPayloadError, Payload]]
            |}
            |object PayloadClient {
            |
            |  final case class UnexpectedErrorResponse(statusCode: Int, value: Error)
-           |  type GetPayloadResponse = UnexpectedErrorResponse
+           |  type GetPayloadError = UnexpectedErrorResponse
            |}""".stripMargin)
     }
 
@@ -152,12 +152,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def getPayload(id: String): F[Either[GetPayloadResponse, Payload]]
+           |  def getPayload(id: String): F[Either[GetPayloadError, Payload]]
            |}
            |object PayloadClient {
            |
-           |  final case class NotFoundResponse(value: String)
-           |  type GetPayloadResponse = NotFoundResponse
+           |  final case class NotFoundError(value: String)
+           |  type GetPayloadError = NotFoundError
            |}""".stripMargin
       )
     }
@@ -170,13 +170,13 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def updatePayload(id: String): F[Either[UpdatePayloadResponse, UpdatedPayload]]
+           |  def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]]
            |}
            |object PayloadClient {
            |
            |  final case class UpdatedPayload(name: String)
            |  final case class NotFound(isDone: Boolean)
-           |  type UpdatePayloadResponse = NotFound
+           |  type UpdatePayloadError = NotFound
            |}""".stripMargin
       )
     }
@@ -202,14 +202,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def updatePayload(id: String): F[Either[UpdatePayloadResponse, UpdatedPayload]]
+           |  def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]]
            |}
            |object PayloadClient {
            |
            |  final case class UpdatedPayload(name: String)
            |  final case class UnexpectedError(isDone: Boolean)
            |  final case class UnexpectedErrorResponse(statusCode: Int, value: UnexpectedError)
-           |  type UpdatePayloadResponse = UnexpectedErrorResponse
+           |  type UpdatePayloadError = UnexpectedErrorResponse
            |}""".stripMargin
       )
     }
@@ -336,7 +336,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |
-           |    def getPayload(id: String): F[Either[GetPayloadResponse, Payload]] = client.fetch[Either[GetPayloadResponse, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
+           |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[Payload].map(x => Coproduct[Payload](x))
            |      case default => default.as[Error].map(x => Coproduct[UnexpectedErrorResponse](UnexpectedErrorResponse(default.status.code, x)))
            |    }
@@ -352,9 +352,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |
-           |    def getPayload(id: String): F[Either[GetPayloadResponse, Payload]] = client.fetch[Either[GetPayloadResponse, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
+           |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[Payload].map(x => Coproduct[Payload](x))
-           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[NotFoundResponse](NotFoundResponse(x)))
+           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[NotFoundError](NotFoundError(x)))
            |    }
            |  }
            |
@@ -381,7 +381,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
           |    import PayloadClient._
           |
-          |    def updatePayload(id: String): F[Either[UpdatePayloadResponse, UpdatedPayload]] = client.fetch[Either[UpdatePayloadResponse, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
+          |    def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]] = client.fetch[Either[UpdatePayloadError, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
           |      case Successful(response) => response.as[UpdatedPayload].map(x => Coproduct[UpdatedPayload](x))
           |      case default => default.as[UnexpectedError].map(x => Coproduct[UnexpectedErrorResponse](UnexpectedErrorResponse(default.status.code, x)))
           |    }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -55,7 +55,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
   "Client trait should able to print" >> {
     import client.print._
     "when a post operation is provided" >> {
-      operations.print(payloadOpenApi.withPath(mediaTypeReferencePost)) must ===( //
+      interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeReferencePost)) must ===( //
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -69,7 +69,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when a put and delete are provided" >> {
-      operations.print(payloadOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -86,7 +86,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when get endpoints are provided" >> {
-      operations.print(payloadOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -103,7 +103,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when optional body and not optional query parameters is provided" >> {
-      operations.print(payloadOpenApi.withPath(mediaTypeOptionBody)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeOptionBody)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -117,7 +117,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when references in the request and the responses" >> {
-      operations.print(payloadOpenApi.withPath(references)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(references)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -131,7 +131,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with a default one" >> {
-      operations.print(payloadOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -146,7 +146,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with not found response" >> {
-      operations.print(payloadOpenApi.withPath(notFoundResponse)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(notFoundResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -162,7 +162,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with anonymous objects" >> {
-      operations.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -179,7 +179,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are simple response and response with anonymous objects" >> {
-      operations.print(anotherPayloadOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
+      interfaceDefinition.print(anotherPayloadOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait AnotherPayloadClient[F[_]] {
@@ -194,7 +194,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses with anonymous objects with default response" >> {
-      operations.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -212,7 +212,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses and multiple error scenarios" >> {
-      operations.print(payloadOpenApi.withPath(multipleResponses)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(multipleResponses)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -229,7 +229,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "two operations with default response" >> {
-      operations.print(payloadOpenApi.withPath(twoOperationsWithDefaultResponse)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(twoOperationsWithDefaultResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -251,7 +251,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when the failure response is empty" >> {
-      operations.print(payloadOpenApi.withPath(emptyErrorResponse)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(emptyErrorResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -266,7 +266,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple failure response are empty" >> {
-      operations.print(payloadOpenApi.withPath(multipleEmptyErrorResponse)) must ===(
+      interfaceDefinition.print(payloadOpenApi.withPath(multipleEmptyErrorResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -282,7 +282,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when a post operation is provided and operation id is not provided" >> {
-      operations.print(
+      interfaceDefinition.print(
         petstoreOpenApi
           .withPath(
             "/pets" -> emptyItemObject.withPost(
@@ -329,7 +329,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
   "share http4s impl should able to print" >> {
     import client.print._
-    import client.http4s.print.impl
+    import client.http4s.print.implDefinition
     import client.http4s.print.Http4sSpecifics
     implicit val none: Http4sSpecifics = new Http4sSpecifics {
       def none[A]                                     = Printer.unit.contramap[A](_ => ())
@@ -337,9 +337,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       def withBody: Printer[String]                   = none
 
     }
-    val printer = impl
+
     "when a put and delete are provided" >> {
-      printer.print(petstoreOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -353,7 +353,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when get endpoints are provided" >> {
-      printer.print(petstoreOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -368,7 +368,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when optional body and not optional query parameters is provided" >> {
-      printer.print(petstoreOpenApi.withPath(mediaTypeOptionBody).withSchema("UpdatePayload" -> Fixed.string())) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(mediaTypeOptionBody).withSchema("UpdatePayload" -> Fixed.string())) must ===(
         """|object PetstoreHttpClient {
            |  implicit val UpdatePayloadEncoder: Encoder[UpdatePayload] = deriveEncoder[UpdatePayload]
            |  implicit val OptionUpdatePayloadEncoder: Encoder[Option[UpdatePayload]] = deriveEncoder[Option[UpdatePayload]]
@@ -386,7 +386,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when references in the request and the responses" >> {
-      printer.print(petstoreOpenApi.withPath(references)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(references)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -400,7 +400,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with a default one" >> {
-      printer.print(petstoreOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -416,7 +416,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with not found response" >> {
-      printer.print(petstoreOpenApi.withPath(notFoundResponse)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(notFoundResponse)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -432,7 +432,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are simple response and response with anonymous objects" >> {
-      printer.print(petstoreOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
         """|object PetstoreHttpClient {
           |
           |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -445,7 +445,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses with anonymous objects with default response" >> {
-      printer.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
+      implDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -461,7 +461,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses and multiple error scenarios" >> {
-      printer.print(payloadOpenApi.withPath(multipleResponses)) must ===(
+      implDefinition.print(payloadOpenApi.withPath(multipleResponses)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -479,7 +479,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with anonymous objects" >> {
-      printer.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
+      implDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -496,7 +496,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when the failure response is empty" >> {
-      printer.print(payloadOpenApi.withPath(emptyErrorResponse)) must ===(
+      implDefinition.print(payloadOpenApi.withPath(emptyErrorResponse)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -513,7 +513,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple failure response are empty" >> {
-      printer.print(payloadOpenApi.withPath(multipleEmptyErrorResponse)) must ===(
+      implDefinition.print(payloadOpenApi.withPath(multipleEmptyErrorResponse)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -533,11 +533,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
   "http4s 0.20.x should able to print" >> {
     import client.print._
-    import client.http4s.print.{openApi => printer}
+    import client.http4s.print.impl
     import client.http4s.print.v20._
 
     "when a post operation is provided" >> {
-      printer.print(
+      impl.print(
         PackageName("petstore") -> petstoreOpenApi
           .withPath(mediaTypeReferencePost)
           .withSchema("NewPayload" -> Fixed.string())
@@ -577,11 +577,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
   "http4s 0.18.x should able to print" >> {
     import client.print._
-    import client.http4s.print.{openApi => printer}
+    import client.http4s.print.impl
     import client.http4s.print.v18._
 
     "when a post operation is provided" >> {
-      printer.print(
+      impl.print(
         PackageName("petstore") -> petstoreOpenApi
           .withPath(mediaTypeReferencePost)
           .withSchema("NewPayload" -> Fixed.string())) must ===(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -299,12 +299,16 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when optional body and not optional query parameters is provided" >> {
-      printer.print(openApi("Petstore").withPath(mediaTypeOptionBody)) must ===(
+      printer.print(openApi("Petstore").withPath(mediaTypeOptionBody).withSchema("UpdatePayload" -> Fixed.string())) must ===(
         """|object PetstoreHttpClient {
-           |
+           |  implicit val UpdatePayloadEncoder: Encoder[UpdatePayload] = deriveEncoder[UpdatePayload]
+           |  implicit val OptionUpdatePayloadEncoder: Encoder[Option[UpdatePayload]] = deriveEncoder[Option[UpdatePayload]]
+           |  implicit val UpdatePayloadDecoder: Decoder[UpdatePayload] = deriveDecoder[UpdatePayload]
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |
+           |    implicit val UpdatePayloadEntityEncoder: EntityEncoder[F, UpdatePayload] = jsonEncoderOf[F, UpdatePayload]
+           |    implicit val OptionUpdatePayloadEntityEncoder: EntityEncoder[F, Option[UpdatePayload]] = jsonEncoderOf[F, Option[UpdatePayload]]
+           |    implicit val UpdatePayloadEntityDecoder: EntityDecoder[F, UpdatePayload] = jsonOf[F, UpdatePayload]
            |    def deletePayload(id: String, size: Long, updatePayload: Option[UpdatePayload]): F[Unit] = client.expect[Unit](Request[F](method = Method.DELETE, uri = baseUrl / "payloads" / id.show +? ("size", size)))
            |  }
            |
@@ -416,10 +420,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import petstore.models._
            |object PetstoreHttpClient {
            |  implicit val NewPayloadEncoder: Encoder[NewPayload] = deriveEncoder[NewPayload]
+           |  implicit val OptionNewPayloadEncoder: Encoder[Option[NewPayload]] = deriveEncoder[Option[NewPayload]]
            |  implicit val NewPayloadDecoder: Decoder[NewPayload] = deriveDecoder[NewPayload]
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |    implicit val NewPayloadEntityEncoder: EntityEncoder[F, NewPayload] = jsonEncoderOf[F, NewPayload]
+           |    implicit val OptionNewPayloadEntityEncoder: EntityEncoder[F, Option[NewPayload]] = jsonEncoderOf[F, Option[NewPayload]]
            |    implicit val NewPayloadEntityDecoder: EntityDecoder[F, NewPayload] = jsonOf[F, NewPayload]
            |    def createPayload(newPayload: NewPayload): F[Unit] = client.expect[Unit](Request[F](method = Method.POST, uri = baseUrl / "payloads")).withBody(newPayload)
            |  }
@@ -458,10 +464,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import petstore.models._
            |object PetstoreHttpClient {
            |  implicit val NewPayloadEncoder: Encoder[NewPayload] = deriveEncoder[NewPayload]
+           |  implicit val OptionNewPayloadEncoder: Encoder[Option[NewPayload]] = deriveEncoder[Option[NewPayload]]
            |  implicit val NewPayloadDecoder: Decoder[NewPayload] = deriveDecoder[NewPayload]
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |    implicit val NewPayloadEntityEncoder: EntityEncoder[F, NewPayload] = jsonEncoderOf[F, NewPayload]
+           |    implicit val OptionNewPayloadEntityEncoder: EntityEncoder[F, Option[NewPayload]] = jsonEncoderOf[F, Option[NewPayload]]
            |    implicit val NewPayloadEntityDecoder: EntityDecoder[F, NewPayload] = jsonOf[F, NewPayload]
            |    def createPayload(newPayload: NewPayload): F[Unit] = client.expect[Unit](Request[F](method = Method.POST, uri = baseUrl / "payloads")).withEntity(newPayload)
            |  }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -543,10 +543,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           .withSchema("NewPayload" -> Fixed.string())
       ) must ===(
         """|import cats.effect._
-           |import cats.syntax.functor._
-           |import cats.syntax.either._
-           |import cats.syntax.show._
-           |import cats.implicits.catsStdShowForLong
+           |import cats.implicits._
            |import org.http4s._
            |import org.http4s.client.Client
            |import org.http4s.client.blaze._
@@ -586,10 +583,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           .withPath(mediaTypeReferencePost)
           .withSchema("NewPayload" -> Fixed.string())) must ===(
         """|import cats.effect._
-           |import cats.syntax.functor._
-           |import cats.syntax.either._
-           |import cats.syntax.show._
-           |import cats.implicits.catsStdShowForLong
+           |import cats.implicits._
            |import org.http4s._
            |import org.http4s.client.Client
            |import org.http4s.client.blaze._

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -469,8 +469,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |    def createPayload(): F[Either[CreatePayloadError, Unit]] = client.fetch[Either[CreatePayloadError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
-           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[CreatePayloadNotFoundError](CreatePayloadNotFoundError(x)).asLeft)
-           |      case default => default.as[Error].map(x => Coproduct[CreatePayloadUnexpectedErrorResponse](CreatePayloadUnexpectedErrorResponse(default.status.code, x)).asLeft)
+           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[CreatePayloadError](CreatePayloadNotFoundError(x)).asLeft)
+           |      case default => default.as[Error].map(x => Coproduct[CreatePayloadError](CreatePayloadUnexpectedErrorResponse(default.status.code, x)).asLeft)
            |    }
            |  }
            |
@@ -521,8 +521,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |    def deletePayloads(): F[Either[DeletePayloadsError, Unit]] = client.fetch[Either[DeletePayloadsError, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
-           |      case response if response.status.code == 404 => response.as[Unit].map(x => Coproduct[DeletePayloadsNotFoundError](DeletePayloadsNotFoundError(x)).asLeft)
-           |      case default => default.as[Unit].map(x => Coproduct[DeletePayloadsUnexpectedErrorResponse](DeletePayloadsUnexpectedErrorResponse(default.status.code, x)).asLeft)
+           |      case response if response.status.code == 404 => response.as[Unit].map(x => Coproduct[DeletePayloadsError](DeletePayloadsNotFoundError(x)).asLeft)
+           |      case default => default.as[Unit].map(x => Coproduct[DeletePayloadsError](DeletePayloadsUnexpectedErrorResponse(default.status.code, x)).asLeft)
            |    }
            |  }
            |

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -28,8 +28,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when a basic type is provided" >> {
       model.print(components("Foo" -> Fixed.string())) must
         ===("""|object models {
-             |  type Foo = String
-             |}""".stripMargin)
+               |  type Foo = String
+               |}""".stripMargin)
     }
 
     "when a object type is provided" >> {
@@ -337,8 +337,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    import PetstoreClient._
            |
            |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
-           |      case Successful(response) => response.as[Payload].map(x => Coproduct[Payload](x))
-           |      case default => default.as[Error].map(x => Coproduct[UnexpectedErrorResponse](UnexpectedErrorResponse(default.status.code, x)))
+           |      case Successful(response) => response.as[Payload].map(_.asRight)
+           |      case default => default.as[Error].map(x => UnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
            |  }
            |
@@ -353,8 +353,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    import PetstoreClient._
            |
            |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
-           |      case Successful(response) => response.as[Payload].map(x => Coproduct[Payload](x))
-           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[NotFoundError](NotFoundError(x)))
+           |      case Successful(response) => response.as[Payload].map(_.asRight)
+           |      case response if response.status.code == 404 => response.as[String].map(x => NotFoundError(x).asLeft)
            |    }
            |  }
            |
@@ -382,8 +382,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           |    import PayloadClient._
           |
           |    def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]] = client.fetch[Either[UpdatePayloadError, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
-          |      case Successful(response) => response.as[UpdatedPayload].map(x => Coproduct[UpdatedPayload](x))
-          |      case default => default.as[UnexpectedError].map(x => Coproduct[UnexpectedErrorResponse](UnexpectedErrorResponse(default.status.code, x)))
+          |      case Successful(response) => response.as[UpdatedPayload].map(_.asRight)
+          |      case default => default.as[UnexpectedError].map(x => UnexpectedErrorResponse(default.status.code, x).asLeft)
           |    }
           |  }
           |

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -568,11 +568,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    implicit val OptionNewPayloadsEntityEncoder: EntityEncoder[F, Option[NewPayloads]] = jsonEncoderOf[F, Option[NewPayloads]]
            |    implicit val NewPayloadEntityDecoder: EntityDecoder[F, NewPayload] = jsonOf[F, NewPayload]
            |    implicit val NewPayloadsEntityDecoder: EntityDecoder[F, NewPayloads] = jsonOf[F, NewPayloads]
-           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads)) {
+           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads)) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
-           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withBody(payloads))
+           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withEntity(payloads))
            |  }
            |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext): Resource[F, PetstoreClient[F]] = BlazeClientBuilder(executionContext).resource.map(PetstoreHttpClient.build(_, baseUrl))
            |}""".stripMargin
@@ -616,11 +616,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    implicit val OptionNewPayloadsEntityEncoder: EntityEncoder[F, Option[NewPayloads]] = jsonEncoderOf[F, Option[NewPayloads]]
            |    implicit val NewPayloadEntityDecoder: EntityDecoder[F, NewPayload] = jsonOf[F, NewPayload]
            |    implicit val NewPayloadsEntityDecoder: EntityDecoder[F, NewPayloads] = jsonOf[F, NewPayloads]
-           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads)) {
+           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads)) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
-           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withEntity(payloads))
+           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withBody(payloads))
            |  }
            |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext): F[PetstoreClient[F]] = Http1Client[F](config = BlazeClientConfig.defaultConfig.copy(executionContext = executionContext)).map(PetstoreHttpClient.build(_, baseUrl))
            |}""".stripMargin

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -539,8 +539,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when a post operation is provided" >> {
       impl.print(
         PackageName("petstore") -> petstoreOpenApi
-          .withPath(mediaTypeReferencePost)
+          .withPath(mediaTypeReferences)
           .withSchema("NewPayload" -> Fixed.string())
+          .withSchema("NewPayloads" -> Fixed.array(Fixed.reference("NewPayload")))
       ) must ===(
         """|import cats.effect._
            |import cats.implicits._
@@ -563,8 +564,15 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    import PetstoreClient._
            |    implicit val NewPayloadEntityEncoder: EntityEncoder[F, NewPayload] = jsonEncoderOf[F, NewPayload]
            |    implicit val OptionNewPayloadEntityEncoder: EntityEncoder[F, Option[NewPayload]] = jsonEncoderOf[F, Option[NewPayload]]
+           |    implicit val NewPayloadsEntityEncoder: EntityEncoder[F, NewPayloads] = jsonEncoderOf[F, NewPayloads]
+           |    implicit val OptionNewPayloadsEntityEncoder: EntityEncoder[F, Option[NewPayloads]] = jsonEncoderOf[F, Option[NewPayloads]]
            |    implicit val NewPayloadEntityDecoder: EntityDecoder[F, NewPayload] = jsonOf[F, NewPayload]
-           |    def createPayload(newPayload: NewPayload): F[Unit] = client.expect[Unit](Request[F](method = Method.POST, uri = baseUrl / "payloads")).withBody(newPayload)
+           |    implicit val NewPayloadsEntityDecoder: EntityDecoder[F, NewPayloads] = jsonOf[F, NewPayloads]
+           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads)) {
+           |      case Successful(response) => response.as[Unit].map(_.asRight)
+           |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
+           |    }
+           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withBody(payloads))
            |  }
            |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext): Resource[F, PetstoreClient[F]] = BlazeClientBuilder(executionContext).resource.map(PetstoreHttpClient.build(_, baseUrl))
            |}""".stripMargin
@@ -580,8 +588,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when a post operation is provided" >> {
       impl.print(
         PackageName("petstore") -> petstoreOpenApi
-          .withPath(mediaTypeReferencePost)
-          .withSchema("NewPayload" -> Fixed.string())) must ===(
+          .withPath(mediaTypeReferences)
+          .withSchema("NewPayload" -> Fixed.string())
+          .withSchema("NewPayloads" -> Fixed.array(Fixed.reference("NewPayload")))) must ===(
         """|import cats.effect._
            |import cats.implicits._
            |import org.http4s._
@@ -603,8 +612,15 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    import PetstoreClient._
            |    implicit val NewPayloadEntityEncoder: EntityEncoder[F, NewPayload] = jsonEncoderOf[F, NewPayload]
            |    implicit val OptionNewPayloadEntityEncoder: EntityEncoder[F, Option[NewPayload]] = jsonEncoderOf[F, Option[NewPayload]]
+           |    implicit val NewPayloadsEntityEncoder: EntityEncoder[F, NewPayloads] = jsonEncoderOf[F, NewPayloads]
+           |    implicit val OptionNewPayloadsEntityEncoder: EntityEncoder[F, Option[NewPayloads]] = jsonEncoderOf[F, Option[NewPayloads]]
            |    implicit val NewPayloadEntityDecoder: EntityDecoder[F, NewPayload] = jsonOf[F, NewPayload]
-           |    def createPayload(newPayload: NewPayload): F[Unit] = client.expect[Unit](Request[F](method = Method.POST, uri = baseUrl / "payloads")).withEntity(newPayload)
+           |    implicit val NewPayloadsEntityDecoder: EntityDecoder[F, NewPayloads] = jsonOf[F, NewPayloads]
+           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads)) {
+           |      case Successful(response) => response.as[Unit].map(_.asRight)
+           |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
+           |    }
+           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withEntity(payloads))
            |  }
            |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext): F[PetstoreClient[F]] = Http1Client[F](config = BlazeClientConfig.defaultConfig.copy(executionContext = executionContext)).map(PetstoreHttpClient.build(_, baseUrl))
            |}""".stripMargin
@@ -648,6 +664,23 @@ object OpenApiPrintSpecification {
       responses = "201"          -> response("Null response")
     ).withOperationId("createPayload")
   )
+
+  val mediaTypeReferences = "/payloads" -> emptyItemObject
+    .withPost(
+      operation[JsonSchemaF.Fixed](
+        request("application/json" -> mediaType(Fixed.reference("#/components/schemas/NewPayloads"))),
+        responses = "201"          -> response(""),
+        defaultError
+      ).withOperationId("createPayloads")
+    )
+    .withPut(
+      operation[JsonSchemaF.Fixed](
+        request("application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads"))),
+        responses = "200" -> response(
+          "",
+          "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
+      ).withOperationId("updatePayloads")
+    )
 
   val mediaTypeReferencePutDelete = payloadPathId -> emptyItemObject
     .withPut(
@@ -787,5 +820,4 @@ object OpenApiPrintSpecification {
       "default" -> response("Unexpected error")
     )
   )
-
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -26,14 +26,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
   "models should able to print" >> {
     "when a basic type is provided" >> {
-      model.print(components("Foo" -> Fixed.string())) must
+      model.print(petstoreOpenApi.withSchema("Foo" -> Fixed.string())) must
         ===("""|object models {
                |  type Foo = String
                |}""".stripMargin)
     }
 
     "when a object type is provided" >> {
-      model.print(components("Foo" -> obj("bar" -> Fixed.string())())) must ===(
+      model.print(petstoreOpenApi.withSchema("Foo" -> obj("bar" -> Fixed.string())())) must ===(
         """|object models {
            |  final case class Foo(bar: Option[String])
            |}""".stripMargin)
@@ -41,10 +41,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when multiple types are provided" >> {
       model.print(
-        components(
-          "Bar"  -> obj("foo" -> Fixed.string())("foo"),
-          "Bars" -> Fixed.array(Fixed.reference("#/components/schemas/Bar"))
-        )) must ===("""|object models {
+        petstoreOpenApi
+          .withSchema("Bar" -> obj("foo" -> Fixed.string())("foo"))
+          .withSchema(
+            "Bars" -> Fixed.array(Fixed.reference("#/components/schemas/Bar"))
+          )) must ===("""|object models {
                        |  final case class Bar(foo: String)
                        |  type Bars = List[Bar]
                        |}""".stripMargin)
@@ -54,7 +55,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
   "Client trait should able to print" >> {
     import client.print._
     "when a post operation is provided" >> {
-      operations.print(paths()(mediaTypeReferencePost)) must ===( //
+      operations.print(payloadOpenApi.withPath(mediaTypeReferencePost)) must ===( //
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -68,7 +69,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when a put and delete are provided" >> {
-      operations.print(paths()(mediaTypeReferencePutDelete)) must ===(
+      operations.print(payloadOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -85,7 +86,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when get endpoints are provided" >> {
-      operations.print(paths()(mediaTypeReferenceGet, mediaTypeReferenceGetId)) must ===(
+      operations.print(payloadOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -102,7 +103,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when optional body and not optional query parameters is provided" >> {
-      operations.print(paths()(mediaTypeOptionBody)) must ===(
+      operations.print(payloadOpenApi.withPath(mediaTypeOptionBody)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -116,7 +117,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when references in the request and the responses" >> {
-      operations.print(paths()(references)) must ===(
+      operations.print(payloadOpenApi.withPath(references)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -130,7 +131,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with a default one" >> {
-      operations.print(paths()(multipleResponsesWithDefaultOne)) must ===(
+      operations.print(payloadOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -145,7 +146,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with not found response" >> {
-      operations.print(paths()(notFoundResponse)) must ===(
+      operations.print(payloadOpenApi.withPath(notFoundResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -161,7 +162,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with anonymous objects" >> {
-      operations.print(paths()(multipleResponsesWithAnonymousObject)) must ===(
+      operations.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -178,7 +179,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are simple response and response with anonymous objects" >> {
-      operations.print(paths("AnotherPayloadClient")(simpleResponseResponseAnonymousObjects)) must ===(
+      operations.print(anotherPayloadOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait AnotherPayloadClient[F[_]] {
@@ -193,7 +194,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses with anonymous objects with default response" >> {
-      operations.print(paths()(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
+      operations.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -211,7 +212,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses and multiple error scenarios" >> {
-      operations.print(paths()(multipleResponses)) must ===(
+      operations.print(payloadOpenApi.withPath(multipleResponses)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -228,7 +229,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "two operations with default response" >> {
-      operations.print(paths()(twoOperationsWithDefaultResponse)) must ===(
+      operations.print(payloadOpenApi.withPath(twoOperationsWithDefaultResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
@@ -251,37 +252,39 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when a post operation is provided and operation id is not provided" >> {
       operations.print(
-        paths("PetsClient")(
-          "/pets" -> emptyItemObject.withPost(
-            operation[JsonSchemaF.Fixed](
-              request("application/json" -> mediaType(Fixed.reference("#/components/schemas/NewPet"))),
-              responses = "200"          -> response("Null response")
-            )
-          ),
-          "/pets/{id}" -> emptyItemObject.withPut(
-            operation[JsonSchemaF.Fixed](
-              request("application/json" -> mediaType(Fixed.reference("#/components/schemas/UpdatePet"))),
-              responses = "201"          -> response("Null response")
-            ).withParameter(path("id", Fixed.string()))
-          ),
-          "/pets/{id}/owners/" -> emptyItemObject.withGet(
-            operation[JsonSchemaF.Fixed](
-              request(),
-              responses = "201" -> response(
-                "Null response",
-                "application/json" -> mediaType(Fixed.reference("#/components/schemas/Owners")))
-            ).withParameter(path("id", Fixed.string()))
-          )
-        )
+        petstoreOpenApi
+          .withPath(
+            "/pets" -> emptyItemObject.withPost(
+              operation[JsonSchemaF.Fixed](
+                request("application/json" -> mediaType(Fixed.reference("#/components/schemas/NewPet"))),
+                responses = "200"          -> response("Null response")
+              )
+            ))
+          .withPath(
+            "/pets/{id}" -> emptyItemObject.withPut(
+              operation[JsonSchemaF.Fixed](
+                request("application/json" -> mediaType(Fixed.reference("#/components/schemas/UpdatePet"))),
+                responses = "201"          -> response("Null response")
+              ).withParameter(path("id", Fixed.string()))
+            ))
+          .withPath(
+            "/pets/{id}/owners/" -> emptyItemObject.withGet(
+              operation[JsonSchemaF.Fixed](
+                request(),
+                responses = "201" -> response(
+                  "Null response",
+                  "application/json" -> mediaType(Fixed.reference("#/components/schemas/Owners")))
+              ).withParameter(path("id", Fixed.string()))
+            ))
       ) must ===("""|import models._
                     |import shapeless.{:+:, CNil}
-                    |trait PetsClient[F[_]] {
-                    |  import PetsClient._
+                    |trait PetstoreClient[F[_]] {
+                    |  import PetstoreClient._
                     |  def createPets(newPet: NewPet): F[Unit]
                     |  def updatePets(id: String, updatePet: UpdatePet): F[Unit]
                     |  def getOwnersPets(id: String): F[Owners]
                     |}
-                    |object PetsClient {
+                    |object PetstoreClient {
                     |
                     |
                     |
@@ -304,7 +307,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
     val printer = impl
     "when a put and delete are provided" >> {
-      printer.print(openApi("Petstore").withPath(mediaTypeReferencePutDelete)) must ===(
+      printer.print(petstoreOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -318,7 +321,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when get endpoints are provided" >> {
-      printer.print(openApi("Petstore").withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
+      printer.print(petstoreOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -333,7 +336,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when optional body and not optional query parameters is provided" >> {
-      printer.print(openApi("Petstore").withPath(mediaTypeOptionBody).withSchema("UpdatePayload" -> Fixed.string())) must ===(
+      printer.print(petstoreOpenApi.withPath(mediaTypeOptionBody).withSchema("UpdatePayload" -> Fixed.string())) must ===(
         """|object PetstoreHttpClient {
            |  implicit val UpdatePayloadEncoder: Encoder[UpdatePayload] = deriveEncoder[UpdatePayload]
            |  implicit val OptionUpdatePayloadEncoder: Encoder[Option[UpdatePayload]] = deriveEncoder[Option[UpdatePayload]]
@@ -351,7 +354,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when references in the request and the responses" >> {
-      printer.print(openApi("Petstore").withPath(references)) must ===(
+      printer.print(petstoreOpenApi.withPath(references)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -365,7 +368,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with a default one" >> {
-      printer.print(openApi("Petstore").withPath(multipleResponsesWithDefaultOne)) must ===(
+      printer.print(petstoreOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -381,7 +384,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with not found response" >> {
-      printer.print(openApi("Petstore").withPath(notFoundResponse)) must ===(
+      printer.print(petstoreOpenApi.withPath(notFoundResponse)) must ===(
         """|object PetstoreHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -397,7 +400,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are simple response and response with anonymous objects" >> {
-      printer.print(openApi("Petstore").withPath(simpleResponseResponseAnonymousObjects)) must ===(
+      printer.print(petstoreOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
         """|object PetstoreHttpClient {
           |
           |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
@@ -410,7 +413,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses with anonymous objects with default response" >> {
-      printer.print(openApi("Payload").withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
+      printer.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -426,7 +429,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses and multiple error scenarios" >> {
-      printer.print(openApi("Payload").withPath(multipleResponses)) must ===(
+      printer.print(payloadOpenApi.withPath(multipleResponses)) must ===(
         """|object PayloadHttpClient {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -444,7 +447,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with anonymous objects" >> {
-      printer.print(openApi("Payload").withPath(multipleResponsesWithAnonymousObject)) must ===(
+      printer.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
         """|object PayloadHttpClient {
           |
           |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
@@ -468,7 +471,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when a post operation is provided" >> {
       printer.print(
-        PackageName("petstore") -> openApi("Petstore")
+        PackageName("petstore") -> petstoreOpenApi
           .withPath(mediaTypeReferencePost)
           .withSchema("NewPayload" -> Fixed.string())
       ) must ===(
@@ -512,7 +515,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when a post operation is provided" >> {
       printer.print(
-        PackageName("petstore") -> openApi("Petstore")
+        PackageName("petstore") -> petstoreOpenApi
           .withPath(mediaTypeReferencePost)
           .withSchema("NewPayload" -> Fixed.string())) must ===(
         """|import cats.effect._
@@ -552,15 +555,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 object OpenApiPrintSpecification {
   import JsonSchemaF.Fixed
   import helpers._
-  import client.print.TraitName
-  import schema.Path.ItemObject
 
   private val pathId        = path("id", Fixed.string())
   private val payloadPath   = "/payloads"
   private val payloadPathId = s"$payloadPath/{id}"
 
-  def paths[T](traitName: String = "PayloadClient")(
-      xs: (String, ItemObject[T])*): (TraitName, Map[String, ItemObject[T]]) = TraitName(traitName) -> xs.toMap
+  def petstoreOpenApi[T]       = openApi[T]("Petstore")
+  def payloadOpenApi[T]        = openApi[T]("Payload")
+  def anotherPayloadOpenApi[T] = openApi[T]("AnotherPayload")
 
   private val successPayload = "200" -> response(
     "Null response",


### PR DESCRIPTION
This PR contains the following features:

- Supports **multiple responses**:
  - Simple `Either` when there is a failure.
  - `Coproduct` of failures when there are multiple failures.
- Supports **anonymous object at the first level** for request and the responses.
- Adds **optional encoders** for the request body.
- Supports **empty responses** in failures.
- Avoids **duplication of types** using the *operation id* in the response.
- **Refactors** to improve readability and simplifies the API.
- Fixes `fetch` method to support `withBody`