### PR TITLE
Print encoders

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/Printer.scala
+++ b/src/main/scala/higherkindness/skeuomorph/Printer.scala
@@ -44,6 +44,10 @@ object Printer {
 
   val unit: Printer[Unit] = Printer(_ => "")
 
+  object avoid {
+    implicit def nonePrinter[T]: Printer[T] = unit.contramap(_ => ())
+  }
+
   def show[F: Show]: Printer[F] = Printer { _.show }
 
   def optional[A](p: Printer[A]): Printer[Option[A]] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -56,6 +56,9 @@ package object circe {
         case ListCodecs(name) =>
           val (default, optionType) = codecsTypes[T](name)
           (http4sPackages, none, none, default, optionType, default)
+        case EnumCodecs(name, _) =>
+          val (default, optionType) = codecsTypes[T](name)
+          (packages, none, none, default, optionType, default)
       }
 
   implicit def http4sCodecsPrinter[T: Basis[JsonSchemaF, ?]]: Printer[EntityCodecs[T]] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.skeuomorph.openapi.client.http4s
+
+import higherkindness.skeuomorph.Printer
+import higherkindness.skeuomorph.Printer._
+import higherkindness.skeuomorph.catz.contrib.ContravariantMonoidalSyntax._
+import higherkindness.skeuomorph.openapi._
+import higherkindness.skeuomorph.openapi.print._
+import client.http4s.print._
+import cats.implicits._
+import qq.droste._
+import cats.implicits._
+
+import higherkindness.skeuomorph.openapi.print.Codecs
+
+package object circe {
+  private val http4sPackages =
+    List("org.http4s.{EntityEncoder, EntityDecoder}", "org.http4s.circe._", "cats.Applicative", "cats.effect.Sync").map(
+      PackageName.apply)
+
+  private val packages =
+    List("io.circe._", "io.circe.generic.semiauto._").map(PackageName.apply) ++ http4sPackages
+
+  implicit def circeCodecsPrinter[T: Basis[JsonSchemaF, ?]]: Printer[Codecs[T]] =
+    (
+      konst("object ") *< tpe[T] >* konst(" {") *< newLine,
+      sepBy(space *< space *< importDef, "\n") >* newLine,
+      optional(space *< space *< circeEncoder[T] >* newLine),
+      optional(space *< space *< circeDecoder[T] >* newLine),
+      space *< space *< entityEncoder[T] >* newLine,
+      space *< space *< entityEncoder[T] >* newLine,
+      space *< space *< entityDecoder[T] >* newLine >* konst("}"))
+      .contramapN { x =>
+        val tpe     = Tpe[T](x.name)
+        val default = x.name -> tpe
+        val (imports, tpeWithName) =
+          if (isArray(x.tpe))
+            http4sPackages -> none
+          else
+            packages -> default.some
+        (tpe, imports, tpeWithName, tpeWithName, default, s"Option${x.name}" -> tpe.copy(required = false), default)
+      }
+
+  implicit def http4sCodecsPrinter[T: Basis[JsonSchemaF, ?]]: Printer[EntityCodecs[T]] =
+    (
+      sepBy(space *< space *< importDef, "\n") >* newLine,
+      space *< space *< entityEncoder[T] >* newLine,
+      space *< space *< entityDecoder[T] >* newLine)
+      .contramapN { x =>
+        val y = x.name -> Tpe[T](x.name)
+        (packages, y, y)
+      }
+
+  def circeDecoder[T: Basis[JsonSchemaF, ?]]: Printer[(String, Tpe[T])] =
+    (
+      konst("implicit val ") *< string >* konst("Decoder: "),
+      konst("Decoder[") *< tpe[T] >* konst("] = "),
+      konst("deriveDecoder[") *< tpe[T] >* konst("]"))
+      .contramapN(x => (x._1, x._2, x._2))
+
+  def circeEncoder[T: Basis[JsonSchemaF, ?]]: Printer[(String, Tpe[T])] =
+    (
+      konst("implicit val ") *< string >* konst("Encoder: "),
+      konst("Encoder[") *< tpe[T] >* konst("] = "),
+      konst("deriveEncoder[") *< tpe[T] >* konst("]"))
+      .contramapN(x => (x._1, x._2, x._2))
+
+  def entityDecoder[T: Basis[JsonSchemaF, ?]]: Printer[(String, Tpe[T])] =
+    (
+      konst("implicit def ") *< string >* konst("EntityDecoder[F[_]:Sync]: "),
+      konst("EntityDecoder[F, ") *< tpe[T] >* konst("] = "),
+      konst("jsonOf[F, ") *< tpe[T] >* konst("]"))
+      .contramapN(x => (x._1, x._2, x._2))
+
+  def entityEncoder[T: Basis[JsonSchemaF, ?]]: Printer[(String, Tpe[T])] =
+    (
+      konst("implicit def ") *< string >* konst("EntityEncoder[F[_]:Applicative]: "),
+      konst("EntityEncoder[F, ") *< tpe[T] >* konst("] = "),
+      konst("jsonEncoderOf[F, ") *< tpe[T] >* konst("]"))
+      .contramapN(x => (x._1, x._2, x._2))
+
+}

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -21,86 +21,48 @@ import higherkindness.skeuomorph.Printer._
 import higherkindness.skeuomorph.catz.contrib.ContravariantMonoidalSyntax._
 import higherkindness.skeuomorph.catz.contrib.Decidable._
 import higherkindness.skeuomorph.openapi._
-import higherkindness.skeuomorph.openapi.print.isArray
+
+import higherkindness.skeuomorph.openapi.print.{schema => _, _}
 import higherkindness.skeuomorph.openapi.client.print._
 import cats.implicits._
 import qq.droste._
 
 object print {
   import schema._
+  final case class EntityCodecs[T](name: String, tpe: T)
 
   def impl[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[(PackageName, OpenApi[T])] =
-    (imports >* newLine, implDefinition[T]).contramapN {
+    (sepBy(importDef, "\n") >* newLine, implDefinition[T]).contramapN {
       case (packageName, openApi) =>
+        val arrays = openApi.components.toList.flatMap(_.schemas.toList).filter { case (_, x) => isArray(x) }.map(_._1)
         (
-          packages ++ List(
+          packages ++ (List(
             s"${packageName.show}.${TraitName(openApi).show}",
             s"${packageName.show}.models._"
-          ).map(PackageName.apply),
+          ) ++ arrays.map(x => s"$x._")).map(PackageName.apply),
           openApi)
     }
 
-  def implDefinition[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[OpenApi[T]] =
-    (
-      konst("object ") *< show[ImplName] >* konst(" {") *< newLine,
-      sepBy(twoSpaces *< (circeEncoder >|< circeDecoder), "\n") >* newLine,
-      konst("  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): ") *< show[TraitName] >* konst("[F]"),
-      konst(" = new ") *< show[TraitName] >* konst("[F] {") >* newLine,
-      twoSpaces *< twoSpaces *< imports >* newLine,
-      sepBy(twoSpaces *< twoSpaces *< (entityEncoder >|< entityDecoder), "\n") >* newLine,
-      sepBy(twoSpaces *< methodImpl(http4sSpecifics.withBody), "\n") >* newLine *< konst("  }") *< newLine,
-      http4sSpecifics.applyMethod >* (newLine *< konst("}"))).contramapN { x =>
+  type ImplDef[T] = (TraitName, TraitName, List[PackageName], List[OperationWithPath[T]], (TraitName, ImplName))
+  def implDefinition[T: Basis[JsonSchemaF, ?]](implicit http4sSpecifics: Http4sSpecifics): Printer[OpenApi[T]] = {
+    objectDef[ImplName, ImplDef[T]](
+      (
+        konst("  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): ") *< show[TraitName] >* konst("[F]"),
+        konst(" = new ") *< show[TraitName] >* konst("[F] {") >* newLine,
+        twoSpaces *< twoSpaces *< sepBy(importDef, "\n") >* newLine,
+        sepBy(twoSpaces *< methodImpl(http4sSpecifics.withBody), "\n") >* newLine *< konst("  }") *< newLine,
+        http4sSpecifics.applyMethod).contramapN(identity)).contramap { x =>
       (
         ImplName(x),
-        encoderAndDecodersFrom(x)(isArray),
-        TraitName(x),
-        TraitName(x),
-        List(PackageName(s"${TraitName(x).show}._")),
-        encoderAndDecodersFrom(x)(_ => false),
-        toOperationsWithPath(TraitName(x) -> x.paths)._2,
-        TraitName(x) -> ImplName(x))
+        List.empty,
+        (
+          TraitName(x),
+          TraitName(x),
+          List(PackageName(s"${TraitName(x).show}._")),
+          toOperationsWithPath(TraitName(x) -> x.paths)._2,
+          TraitName(x) -> ImplName(x)))
     }
-
-  def encoderAndDecodersFrom[T: Basis[JsonSchemaF, ?]](openApi: OpenApi[T])(
-      f: T => Boolean): List[Either[Encoder[T], Decoder[T]]] = {
-    val xs = openApi.components.toList.flatMap(_.schemas).filterNot { case (_, x) => f(x) }.map(_._1)
-    xs.flatMap { x =>
-      List(
-        Encoder[T](Var(x, Tpe.apply(x))).asLeft,
-        Encoder[T](Var(s"Option$x", Tpe.apply[T](x).copy(required = false))).asLeft)
-    } ++
-      xs.map(x => Decoder[T](Var(x, Tpe.apply(x))).asRight)
   }
-
-  def varTuple[T](x: Var[T]): (String, Tpe[T], Tpe[T]) = ((x.name, x.tpe, x.tpe))
-
-  def circeDecoder[T: Basis[JsonSchemaF, ?]]: Printer[Decoder[T]] =
-    (
-      konst("implicit val ") *< string >* konst("Decoder: "),
-      konst("Decoder[") *< tpe[T] >* konst("] = "),
-      konst("deriveDecoder[") *< tpe[T] >* konst("]"))
-      .contramapN(x => varTuple(x.value))
-
-  def circeEncoder[T: Basis[JsonSchemaF, ?]]: Printer[Encoder[T]] =
-    (
-      konst("implicit val ") *< string >* konst("Encoder: "),
-      konst("Encoder[") *< tpe[T] >* konst("] = "),
-      konst("deriveEncoder[") *< tpe[T] >* konst("]"))
-      .contramapN(x => varTuple(x.value))
-
-  def entityDecoder[T: Basis[JsonSchemaF, ?]]: Printer[Decoder[T]] =
-    (
-      konst("implicit val ") *< string >* konst("EntityDecoder: "),
-      konst("EntityDecoder[F, ") *< tpe[T] >* konst("] = "),
-      konst("jsonOf[F, ") *< tpe[T] >* konst("]"))
-      .contramapN(x => varTuple(x.value))
-
-  def entityEncoder[T: Basis[JsonSchemaF, ?]]: Printer[Encoder[T]] =
-    (
-      konst("implicit val ") *< string >* konst("EntityEncoder: "),
-      konst("EntityEncoder[F, ") *< tpe[T] >* konst("] = "),
-      konst("jsonEncoderOf[F, ") *< tpe[T] >* konst("]"))
-      .contramapN(x => varTuple(x.value))
 
   def successResponseImpl[T: Basis[JsonSchemaF, ?]]: Printer[Either[Response[T], Reference]] =
     (konst("case Successful(response) => response.as[") *< responseOrType[T] >* konst("].map(_.asRight)"))
@@ -234,8 +196,6 @@ object print {
     "org.http4s.client.blaze._",
     "org.http4s.circe._",
     "org.http4s.Status.Successful",
-    "io.circe._",
-    "io.circe.generic.semiauto._",
     "shapeless.Coproduct",
     "scala.concurrent.ExecutionContext"
   ).map(PackageName.apply)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -53,7 +53,7 @@ object print {
         sepBy(twoSpaces *< methodImpl(http4sSpecifics.withBody), "\n") >* newLine *< konst("  }") *< newLine,
         http4sSpecifics.applyMethod).contramapN(identity)).contramap { x =>
       (
-        ObjectName(ImplName(x).show),
+        ImplName(x).show,
         List.empty,
         (
           TraitName(x),

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -17,7 +17,7 @@
 package higherkindness.skeuomorph.openapi.client
 
 import higherkindness.skeuomorph.Printer
-import higherkindness.skeuomorph.Printer._
+import higherkindness.skeuomorph.Printer.{konst => κ, _}
 import higherkindness.skeuomorph.catz.contrib.ContravariantMonoidalSyntax._
 import higherkindness.skeuomorph.catz.contrib.Decidable._
 import higherkindness.skeuomorph.openapi._
@@ -175,9 +175,9 @@ object print {
 
   def method[T: Basis[JsonSchemaF, ?]]: Printer[OperationWithPath[T]] =
     (
-      konst("  def ") *< show[OperationId],
-      konst("(") *< sepBy(argumentDef, ", "),
-      konst("): F[") *< responsesTypes >* konst("]")
+      κ("  def ") *< show[OperationId],
+      κ("(") *< sepBy(argumentDef, ", "),
+      κ("): F[") *< responsesTypes >* κ("]")
     ).contramapN(operationTuple[T])
 
   private def itemObjectTuple[T](xs: (String, ItemObject[T])): List[OperationWithPath[T]] = {
@@ -293,7 +293,7 @@ object print {
         .asRight
 
   private def responseErrorsDef: Printer[List[String]] =
-    (sepBy(string, " :+: "), (konst(" :+: CNil") >|< unit)).contramapN(errorTypes =>
+    (sepBy(string, " :+: "), (κ(" :+: CNil") >|< unit)).contramapN(errorTypes =>
       (errorTypes, if (errorTypes.size > 1) ().asLeft else ().asRight))
 
   private def multipleResponsesSchema: Printer[(List[String], String, List[String])] = {
@@ -359,9 +359,9 @@ object print {
   def interfaceDefinition[T: Basis[JsonSchemaF, ?]](implicit codecs: Printer[Codecs]): Printer[OpenApi[T]] =
     (
       sepBy(importDef, "\n") >* newLine,
-      konst("trait ") *< show[TraitName] >* konst("[F[_]] {") >* newLine,
-      space *< space *< konst("import ") *< show[TraitName] >* konst("._") >* newLine,
-      sepBy(method[T], "\n") >* (newLine >* konst("}") >* newLine),
+      κ("trait ") *< show[TraitName] >* κ("[F[_]] {") >* newLine,
+      space *< space *< κ("import ") *< show[TraitName] >* κ("._") >* newLine,
+      sepBy(method[T], "\n") >* (newLine >* κ("}") >* newLine),
       objectDef(clientTypes[T])
     ).contramapN(operationsTuple[T])
 

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -319,7 +319,8 @@ object print {
       if name === newType
     } yield (newType -> requestTpe)
 
-  private def requestSchema[T: Basis[JsonSchemaF, ?]]: Printer[(OperationId, Option[Either[Request[T], Reference]])] =
+  private def requestSchema[T: Basis[JsonSchemaF, ?]](
+      implicit codecs: Printer[Codecs]): Printer[(OperationId, Option[Either[Request[T], Reference]])] =
     (optional((space >* space) *< schemaWithName[T])).contramap((requestSchemaTuple[T] _).tupled)
 
   private def clientTypes[T: Basis[JsonSchemaF, ?]](

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -73,11 +73,21 @@ object print {
     Printer(scheme.cata(algebra))
   }
 
+  def isTypeAlias[T: Basis[JsonSchemaF, ?]](t: T): Boolean = {
+    import JsonSchemaF._
+    val algebra: Algebra[JsonSchemaF, Boolean] = Algebra {
+      case ObjectF(_, _) => false
+      case EnumF(_)      => false
+      case _             => true
+    }
+    scheme.cata(algebra).apply(t)
+  }
   def isBasic[T: Basis[JsonSchemaF, ?]](t: T): Boolean = {
     import JsonSchemaF._
     val algebra: Algebra[JsonSchemaF, Boolean] = Algebra {
       case ObjectF(_, _) => false
       case EnumF(_)      => false
+      case ArrayF(_)     => false
       case _             => true
     }
     scheme.cata(algebra).apply(t)
@@ -94,7 +104,7 @@ object print {
 
   def schemaPair[T: Basis[JsonSchemaF, ?]]: Printer[(String, T)] = Printer {
     case (name, tpe) =>
-      if (isBasic(tpe)) s"type $name = ${schema().print(tpe)}" else schema(name.some).print(tpe)
+      if (isTypeAlias(tpe)) s"type $name = ${schema().print(tpe)}" else schema(name.some).print(tpe)
   }
 
   final case class Codecs[T](name: String, tpe: T)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -56,7 +56,10 @@ object print {
           val comma                            = if (requiredFields.nonEmpty && optionalFields.nonEmpty) ", " else ""
           val printRequired                    = requiredFields.map(x => s"${x.name}: ${x.tpe}").mkString(", ")
           val printOptional                    = optionalFields.map(x => s"${x.name}: Option[${x.tpe}]").mkString(", ")
-          s"final case class $name($printRequired$comma$printOptional)"
+          if (properties.isEmpty)
+            s"type $name = io.circe.Json"
+          else
+            s"final case class $name($printRequired$comma$printOptional)"
         case (ArrayF(x), _) => s"List[$x]"
         case (EnumF(fields), Some(name)) =>
           val printFields = fields.map(f => s"final case object ${f.capitalize} extends $name").mkString("\n  ")

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -177,6 +177,10 @@ object print {
         (name, tpe, codecInfo.map { case (x, y) => (name, x, y) })
     }
 
+  def implicitVal[T: Basis[JsonSchemaF, ?], A](body: Printer[A]): Printer[(String, String, Tpe[T], A)] =
+    (κ("implicit val ") *< string, string >* κ(": "), divBy(string, κ("["), tpe[T] >* κ("] = ")), body)
+      .contramapN { case (a, b, c, d) => (a, b, (b, c), d) }
+
   def objectDef[A](body: Printer[A]): Printer[(String, List[PackageName], A)] =
     divBy(
       divBy(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -111,13 +111,15 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
 
     "when enum is provided" >> {
       schemaWithName
-        .print("Color" -> Fixed.enum(List("blue", "red", "yellow"))) must ===("""
-          |sealed trait Color
-          |object Color {
-          |  final case object Blue extends Color
-          |  final case object Red extends Color
-          |  final case object Yellow extends Color
-          |}""".stripMargin)
+        .print("Color" -> Fixed.enum(List("Blue", "Red", "Yellow"))) must
+        ===("""|sealed trait Color
+               |object Color {
+               |
+               |  final case object Blue extends Color
+               |  final case object Red extends Color
+               |  final case object Yellow extends Color
+               |
+               |}""".stripMargin)
     }
   }
 

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -15,65 +15,65 @@
  */
 
 package higherkindness.skeuomorph.openapi
-import cats.implicits._
 import higherkindness.skeuomorph.Printer.avoid._
 
 class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
   import JsonSchemaF.Fixed
-  import print._
+  import print.schemaWithName
 
   "basic types should able to print" >> {
     "when integer is provided" >> {
-      schema().print(Fixed.integer()) must ===("Int")
+      print.schema().print(Fixed.integer()) must ===("Int")
     }
     "when long is provided" >> {
-      schema().print(Fixed.long()) must ===("Long")
+      print.schema().print(Fixed.long()) must ===("Long")
     }
     "when float is provided" >> {
-      schema().print(Fixed.float()) must ===("Float")
+      print.schema().print(Fixed.float()) must ===("Float")
     }
     "when double is provided" >> {
-      schema().print(Fixed.double()) must ===("Double")
+      print.schema().print(Fixed.double()) must ===("Double")
     }
     "when string is provided" >> {
-      schema().print(Fixed.string()) must ===("String")
+      print.schema().print(Fixed.string()) must ===("String")
     }
     "when byte is provided" >> {
-      schema().print(Fixed.byte()) must ===("Array[Byte]")
+      print.schema().print(Fixed.byte()) must ===("Array[Byte]")
     }
     "when binary is provided" >> {
-      schema().print(Fixed.binary()) must ===("List[Boolean]")
+      print.schema().print(Fixed.binary()) must ===("List[Boolean]")
     }
     "when boolean is provided" >> {
-      schema().print(Fixed.boolean()) must ===("Boolean")
+      print.schema().print(Fixed.boolean()) must ===("Boolean")
     }
     "when date is provided" >> {
-      schema().print(Fixed.date()) must ===("java.time.LocalDate")
+      print.schema().print(Fixed.date()) must ===("java.time.LocalDate")
     }
     "when datetime is provided" >> {
-      schema().print(Fixed.dateTime()) must ===("java.time.ZonedDateTime")
+      print.schema().print(Fixed.dateTime()) must ===("java.time.ZonedDateTime")
     }
     "when password is provided" >> {
-      schema().print(Fixed.password()) must ===("String")
+      print.schema().print(Fixed.password()) must ===("String")
     }
   }
 
   "complex types should able to print" >> {
     "when an empty object is provided" >> {
-      schema("Person".some)
-        .print(Fixed.`object`(List.empty, List.empty)) must ===("type Person = io.circe.Json")
+      schemaWithName
+        .print("Person" -> Fixed.`object`(List.empty, List.empty)) must ===("type Person = io.circe.Json")
     }
 
     "when object is provided" >> {
-      schema("Person".some)
+      schemaWithName
         .print(
-          Fixed.`object`(
-            List(
-              "name"    -> Fixed.string(),
-              "surname" -> Fixed.string(),
-              "age"     -> Fixed.integer(),
-              "email"   -> Fixed.string()),
-            List("name", "surname"))) must ===(
+          "Person" ->
+            Fixed.`object`(
+              List(
+                "name"    -> Fixed.string(),
+                "surname" -> Fixed.string(),
+                "age"     -> Fixed.integer(),
+                "email"   -> Fixed.string()),
+              List("name", "surname"))) must ===(
         s"""|final case class Person(name: String, surname: String, age: Option[Int], email: Option[String])
             |object Person {
             |
@@ -82,8 +82,10 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when object is provided without required fields" >> {
-      schema("Person".some)
-        .print(Fixed.`object`(List("age" -> Fixed.integer(), "email" -> Fixed.string()), List("name", "surname"))) must ===(
+      schemaWithName
+        .print(
+          "Person" -> Fixed
+            .`object`(List("age" -> Fixed.integer(), "email" -> Fixed.string()), List("name", "surname"))) must ===(
         s"""|final case class Person(age: Option[Int], email: Option[String])
             |object Person {
             |
@@ -92,14 +94,15 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when object is provided without optional fields" >> {
-      schema("Person".some)
+      schemaWithName
         .print(
-          Fixed.`object`(
-            List(
-              "name"    -> Fixed.string(),
-              "surname" -> Fixed.string()
-            ),
-            List("name", "surname"))) must ===(s"""|final case class Person(name: String, surname: String)
+          "Person" ->
+            Fixed.`object`(
+              List(
+                "name"    -> Fixed.string(),
+                "surname" -> Fixed.string()
+              ),
+              List("name", "surname"))) must ===(s"""|final case class Person(name: String, surname: String)
                                                    |object Person {
                                                    |
                                                    |
@@ -107,8 +110,8 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when enum is provided" >> {
-      schema("Color".some)
-        .print(Fixed.enum(List("blue", "red", "yellow"))) must ===("""
+      schemaWithName
+        .print("Color" -> Fixed.enum(List("blue", "red", "yellow"))) must ===("""
           |sealed trait Color
           |object Color {
           |  final case object Blue extends Color

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -58,6 +58,11 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
   }
 
   "complex types should able to print" >> {
+    "when an empty object is provided" >> {
+      schema("Person".some)
+        .print(Fixed.`object`(List.empty, List.empty)) must ===("type Person = io.circe.Json")
+    }
+
     "when object is provided" >> {
       schema("Person".some)
         .print(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -16,6 +16,7 @@
 
 package higherkindness.skeuomorph.openapi
 import cats.implicits._
+import higherkindness.skeuomorph.Printer.avoid._
 
 class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
   import JsonSchemaF.Fixed
@@ -73,13 +74,21 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
               "age"     -> Fixed.integer(),
               "email"   -> Fixed.string()),
             List("name", "surname"))) must ===(
-        "final case class Person(name: String, surname: String, age: Option[Int], email: Option[String])")
+        s"""|final case class Person(name: String, surname: String, age: Option[Int], email: Option[String])
+            |object Person {
+            |
+            |
+            |}""".stripMargin)
     }
 
     "when object is provided without required fields" >> {
       schema("Person".some)
         .print(Fixed.`object`(List("age" -> Fixed.integer(), "email" -> Fixed.string()), List("name", "surname"))) must ===(
-        "final case class Person(age: Option[Int], email: Option[String])")
+        s"""|final case class Person(age: Option[Int], email: Option[String])
+            |object Person {
+            |
+            |
+            |}""".stripMargin)
     }
 
     "when object is provided without optional fields" >> {
@@ -90,7 +99,11 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
               "name"    -> Fixed.string(),
               "surname" -> Fixed.string()
             ),
-            List("name", "surname"))) must ===("final case class Person(name: String, surname: String)")
+            List("name", "surname"))) must ===(s"""|final case class Person(name: String, surname: String)
+                                                   |object Person {
+                                                   |
+                                                   |
+                                                   |}""".stripMargin)
     }
 
     "when enum is provided" >> {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -80,6 +80,32 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}""".stripMargin)
     }
 
+    "when enum is provided" >> {
+      import client.http4s.circe._
+      model.print(petstoreOpenApi.withSchema("Color" -> Fixed.enum(List("Blue", "Red")))) must ===(
+        """|object models {
+           |
+           |sealed trait Color
+           |object Color {
+           |
+           |  final case object Blue extends Color
+           |  final case object Red extends Color
+           |  import io.circe._
+           |  import io.circe.generic.semiauto._
+           |  import org.http4s.{EntityEncoder, EntityDecoder}
+           |  import org.http4s.circe._
+           |  import cats.Applicative
+           |  import cats.effect.Sync
+           |  implicit def ColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Color] = jsonEncoderOf[F, Color]
+           |  implicit def OptionColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Color]] = jsonEncoderOf[F, Option[Color]]
+           |  implicit def ColorEntityDecoder[F[_]:Sync]: EntityDecoder[F, Color] = jsonOf[F, Color]
+           |
+           |}
+           |}""".stripMargin
+      )
+
+    }
+
     "when multiple types are provided" >> {
       import Printer.avoid._
       model.print(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -298,6 +298,17 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  final case class UpdateAnotherPayloadRequest(name: String)
            |object UpdateAnotherPayloadRequest {
            |
+           |  import io.circe._
+           |  import io.circe.generic.semiauto._
+           |  import org.http4s.{EntityEncoder, EntityDecoder}
+           |  import org.http4s.circe._
+           |  import cats.Applicative
+           |  import cats.effect.Sync
+           |  implicit val UpdateAnotherPayloadRequestEncoder: Encoder[UpdateAnotherPayloadRequest] = deriveEncoder[UpdateAnotherPayloadRequest]
+           |  implicit val UpdateAnotherPayloadRequestDecoder: Decoder[UpdateAnotherPayloadRequest] = deriveDecoder[UpdateAnotherPayloadRequest]
+           |  implicit def UpdateAnotherPayloadRequestEntityEncoder[F[_]:Applicative]: EntityEncoder[F, UpdateAnotherPayloadRequest] = jsonEncoderOf[F, UpdateAnotherPayloadRequest]
+           |  implicit def OptionUpdateAnotherPayloadRequestEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[UpdateAnotherPayloadRequest]] = jsonEncoderOf[F, Option[UpdateAnotherPayloadRequest]]
+           |  implicit def UpdateAnotherPayloadRequestEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdateAnotherPayloadRequest] = jsonOf[F, UpdateAnotherPayloadRequest]
            |
            |}
            |  final case class UpdatedPayload(name: String)
@@ -319,17 +330,6 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |}""".stripMargin
       )
-      // |  import io.circe._
-      //   |  import io.circe.generic.semiauto._
-      //   |  import org.http4s.{EntityEncoder, EntityDecoder}
-      //   |  import org.http4s.circe._
-      //   |  import cats.Applicative
-      //   |  import cats.effect.Sync
-      //   |  implicit val UpdateAnotherPayloadRequestEncoder: Encoder[UpdateAnotherPayloadRequest] = deriveEncoder[UpdateAnotherPayloadRequest]
-      //   |  implicit val UpdateAnotherPayloadRequestDecoder: Decoder[UpdateAnotherPayloadRequest] = deriveDecoder[UpdateAnotherPayloadRequest]
-      //   |  implicit def UpdateAnotherPayloadRequestEntityEncoder[F[_]:Applicative]: EntityEncoder[F, UpdateAnotherPayloadRequest] = jsonEncoderOf[F, UpdatedPayload]
-      //   |  implicit def OptionUpdateAnotherPayloadRequestEncoder[F[_]:Applicative]: EntityEncoder[F, Option[UpdateAnotherPayloadRequest]] = jsonEncoderOf[F, Option[UpdatedPayload]]
-      //   |  implicit def UpdateAnotherPayloadRequestdEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdateAnotherPayloadRequest] = jsonOf[F, UpdateAnotherPayloadRequest]
 
     }
 
@@ -509,7 +509,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     implicit val none: Http4sSpecifics = new Http4sSpecifics {
       def none[A]                                     = Printer.unit.contramap[A](_ => ())
       def applyMethod: Printer[(TraitName, ImplName)] = none
-      def withBody: Printer[String]                   = none
+      def withBody: Printer[String] = Printer { x =>
+        s".with($x)"
+      }
 
     }
 
@@ -520,7 +522,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |    def deletePayload(id: String): F[Unit] = client.expect[Unit](Request[F](method = Method.DELETE, uri = baseUrl / "payloads" / id.show))
-           |    def updatePayload(id: String, updatePayload: UpdatePayload): F[Unit] = client.expect[Unit](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show))
+           |    def updatePayload(id: String, updatePayload: UpdatePayload): F[Unit] = client.expect[Unit](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show).with(updatePayload))
            |  }
            |
            |}""".stripMargin)
@@ -546,7 +548,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |    def deletePayload(id: String, size: Long, updatePayload: Option[UpdatePayload]): F[Unit] = client.expect[Unit](Request[F](method = Method.DELETE, uri = baseUrl / "payloads" / id.show +? ("size", size)))
+           |    def deletePayload(id: String, size: Long, updatePayload: Option[UpdatePayload]): F[Unit] = client.expect[Unit](Request[F](method = Method.DELETE, uri = baseUrl / "payloads" / id.show +? ("size", size)).with(updatePayload))
            |  }
            |
            |}""".stripMargin
@@ -559,7 +561,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |    def updatePayload(updatePayload: UpdatePayload): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads"))
+           |    def updatePayload(updatePayload: UpdatePayload): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads").with(updatePayload))
            |  }
            |
            |}""".stripMargin
@@ -602,7 +604,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           |
           |  def build[F[_]: Effect](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
           |    import PetstoreClient._
-          |    def updateAnotherPayload(id: String, updateAnotherPayloadRequest: UpdateAnotherPayloadRequest): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show))
+          |    def updateAnotherPayload(id: String, updateAnotherPayloadRequest: UpdateAnotherPayloadRequest): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show).with(updateAnotherPayloadRequest))
           |  }
           |
           |}""".stripMargin)

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -97,6 +97,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  import cats.Applicative
            |  import cats.effect.Sync
            |  import cats.implicits._
+           |  implicit val ColorShow: Show[Color] = Show.show {
+           |  case Blue => "Blue"
+           |  case Red => "Red"
+           |}
            |  implicit val ColorEncoder: Encoder[Color] = Encoder.encodeString.contramap(_.show)
            |  implicit val ColorDecoder: Decoder[Color] = Decoder.decodeString.emap {
            |  case "Blue" => Blue.asRight

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -29,16 +29,20 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when a basic type is provided" >> {
       model.print(petstoreOpenApi.withSchema("Foo" -> Fixed.string())) must
         ===("""|object models {
+               |
                |  type Foo = String
                |  
+               |
                |}""".stripMargin)
     }
 
     "when a object type is provided" >> {
       model.print(petstoreOpenApi.withSchema("Foo" -> obj("bar" -> Fixed.string())())) must ===(
         """|object models {
+           |
            |  final case class Foo(bar: Option[String])
            |  
+           |
            |}""".stripMargin)
     }
 
@@ -49,10 +53,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           .withSchema(
             "Bars" -> Fixed.array(Fixed.reference("#/components/schemas/Bar"))
           )) must ===("""|object models {
+                         |
                          |  final case class Bar(foo: String)
                          |  type Bars = List[Bar]
                          |  
                          |  
+                         |
                          |}""".stripMargin)
     }
   }
@@ -124,6 +130,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |object PayloadClient {
            |
            |
+           |
+           |
            |}""".stripMargin)
     }
 
@@ -137,6 +145,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def updatePayload(id: String, updatePayload: UpdatePayload): F[Unit]
            |}
            |object PayloadClient {
+           |
+           |
            |
            |
            |
@@ -158,6 +168,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |
            |
+           |
+           |
            |}""".stripMargin)
     }
 
@@ -170,6 +182,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def deletePayload(id: String, size: Long, updatePayload: Option[UpdatePayload]): F[Unit]
            |}
            |object PayloadClient {
+           |
+           |
            |
            |
            |}""".stripMargin)
@@ -186,6 +200,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |object PayloadClient {
            |
            |
+           |
+           |
            |}""".stripMargin)
     }
 
@@ -199,8 +215,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class GetPayloadUnexpectedErrorResponse(statusCode: Int, value: Error)
            |  type GetPayloadError = GetPayloadUnexpectedErrorResponse
+           |
            |}""".stripMargin)
     }
 
@@ -214,8 +232,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class GetPayloadNotFoundError(value: String)
            |  type GetPayloadError = GetPayloadNotFoundError
+           |
            |}""".stripMargin
       )
     }
@@ -230,9 +250,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class UpdatedPayload(name: String)
            |  final case class UpdatePayloadNotFound(isDone: Boolean)
            |  type UpdatePayloadError = UpdatePayloadNotFound
+           |
            |}""".stripMargin
       )
     }
@@ -246,8 +268,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def updateAnotherPayload(id: String, updateAnotherPayloadRequest: UpdateAnotherPayloadRequest): F[UpdatedPayload]
            |}
            |object AnotherPayloadClient {
+           |
            |  final case class UpdateAnotherPayloadRequest(name: String)
            |  final case class UpdatedPayload(name: String)
+           |
            |}""".stripMargin
       )
     }
@@ -262,10 +286,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class UpdatedPayload(name: String)
            |  final case class UpdatePayloadUnexpectedError(isDone: Boolean)
            |  final case class UpdatePayloadUnexpectedErrorResponse(statusCode: Int, value: UpdatePayloadUnexpectedError)
            |  type UpdatePayloadError = UpdatePayloadUnexpectedErrorResponse
+           |
            |}""".stripMargin
       )
     }
@@ -280,9 +306,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class CreatePayloadNotFoundError(value: String)
            |  final case class CreatePayloadUnexpectedErrorResponse(statusCode: Int, value: Error)
            |  type CreatePayloadError = CreatePayloadNotFoundError :+: CreatePayloadUnexpectedErrorResponse :+: CNil
+           |
            |}""".stripMargin
       )
     }
@@ -299,12 +327,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |object PayloadClient {
            |
            |
+           |
            |  final case class CreatePayloadsUnexpectedError(name: String)
            |  final case class CreatePayloadsUnexpectedErrorResponse(statusCode: Int, value: CreatePayloadsUnexpectedError)
            |  type CreatePayloadsError = CreatePayloadsUnexpectedErrorResponse
            |  final case class UpdatePayloadsUnexpectedError(isDone: Boolean)
            |  final case class UpdatePayloadsUnexpectedErrorResponse(statusCode: Int, value: UpdatePayloadsUnexpectedError)
            |  type UpdatePayloadsError = UpdatePayloadsUnexpectedErrorResponse
+           |
            |}""".stripMargin
       )
     }
@@ -319,8 +349,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class DeletePayloadsNotFoundError(value: Unit)
            |  type DeletePayloadsError = DeletePayloadsNotFoundError
+           |
            |}""".stripMargin)
     }
 
@@ -334,9 +366,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |object PayloadClient {
            |
+           |
            |  final case class DeletePayloadsNotFoundError(value: Unit)
            |  final case class DeletePayloadsUnexpectedErrorResponse(statusCode: Int, value: Unit)
            |  type DeletePayloadsError = DeletePayloadsNotFoundError :+: DeletePayloadsUnexpectedErrorResponse :+: CNil
+           |
            |}""".stripMargin)
     }
 
@@ -375,6 +409,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
                     |  def getOwnersPets(id: String): F[Owners]
                     |}
                     |object PetstoreClient {
+                    |
+                    |
                     |
                     |
                     |

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -72,6 +72,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  import org.http4s.circe._
            |  import cats.Applicative
            |  import cats.effect.Sync
+           |  
+           |  
            |  implicit def BarsEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Bars] = jsonEncoderOf[F, Bars]
            |  implicit def OptionBarsEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Bars]] = jsonEncoderOf[F, Option[Bars]]
            |  implicit def BarsEntityDecoder[F[_]:Sync]: EntityDecoder[F, Bars] = jsonOf[F, Bars]
@@ -90,17 +92,18 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |  final case object Blue extends Color
            |  final case object Red extends Color
-           |  import io.circe._
-           |  import io.circe.generic.semiauto._
            |  import org.http4s.{EntityEncoder, EntityDecoder}
            |  import org.http4s.circe._
            |  import cats.Applicative
            |  import cats.effect.Sync
+           |  import cats.implicits._
+           |  implicit val ColorEncoder: Encoder[Color] = Encoder.encodeString.contramap(_.show)
            |  implicit val ColorDecoder: Decoder[Color] = Decoder.decodeString.emap {
            |  case "Blue" => Blue.asRight
            |  case "Red" => Red.asRight
            |  case x => s"$x is not valid Color".asLeft
            |}
+           |
            |  implicit def ColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Color] = jsonEncoderOf[F, Color]
            |  implicit def OptionColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Color]] = jsonEncoderOf[F, Option[Color]]
            |  implicit def ColorEntityDecoder[F[_]:Sync]: EntityDecoder[F, Color] = jsonOf[F, Color]

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -105,7 +105,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
   "Client trait should able to print" >> {
     import client.print._
+
     "when a post operation is provided" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeReferencePost)) must ===( //
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -122,6 +124,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when a put and delete are provided" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -141,6 +144,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when get endpoints are provided" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -160,6 +164,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when optional body and not optional query parameters is provided" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeOptionBody)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -176,6 +181,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when references in the request and the responses" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(references)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -192,6 +198,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with a default one" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -209,6 +216,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with not found response" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(notFoundResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -227,6 +235,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are multiple responses with anonymous objects" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -240,11 +249,33 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  final case class UpdatedPayload(name: String)
            |object UpdatedPayload {
            |
+           |  import io.circe._
+           |  import io.circe.generic.semiauto._
+           |  import org.http4s.{EntityEncoder, EntityDecoder}
+           |  import org.http4s.circe._
+           |  import cats.Applicative
+           |  import cats.effect.Sync
+           |  implicit val UpdatedPayloadEncoder: Encoder[UpdatedPayload] = deriveEncoder[UpdatedPayload]
+           |  implicit val UpdatedPayloadDecoder: Decoder[UpdatedPayload] = deriveDecoder[UpdatedPayload]
+           |  implicit def UpdatedPayloadEntityEncoder[F[_]:Applicative]: EntityEncoder[F, UpdatedPayload] = jsonEncoderOf[F, UpdatedPayload]
+           |  implicit def OptionUpdatedPayloadEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[UpdatedPayload]] = jsonEncoderOf[F, Option[UpdatedPayload]]
+           |  implicit def UpdatedPayloadEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdatedPayload] = jsonOf[F, UpdatedPayload]
            |
            |}
            |  final case class UpdatePayloadNotFound(isDone: Boolean)
            |object UpdatePayloadNotFound {
            |
+           |  import io.circe._
+           |  import io.circe.generic.semiauto._
+           |  import org.http4s.{EntityEncoder, EntityDecoder}
+           |  import org.http4s.circe._
+           |  import cats.Applicative
+           |  import cats.effect.Sync
+           |  implicit val UpdatePayloadNotFoundEncoder: Encoder[UpdatePayloadNotFound] = deriveEncoder[UpdatePayloadNotFound]
+           |  implicit val UpdatePayloadNotFoundDecoder: Decoder[UpdatePayloadNotFound] = deriveDecoder[UpdatePayloadNotFound]
+           |  implicit def UpdatePayloadNotFoundEntityEncoder[F[_]:Applicative]: EntityEncoder[F, UpdatePayloadNotFound] = jsonEncoderOf[F, UpdatePayloadNotFound]
+           |  implicit def OptionUpdatePayloadNotFoundEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[UpdatePayloadNotFound]] = jsonEncoderOf[F, Option[UpdatePayloadNotFound]]
+           |  implicit def UpdatePayloadNotFoundEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdatePayloadNotFound] = jsonOf[F, UpdatePayloadNotFound]
            |
            |}
            |  type UpdatePayloadError = UpdatePayloadNotFound
@@ -254,6 +285,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are simple response and response with anonymous objects" >> {
+      import client.http4s.circe._
       interfaceDefinition.print(anotherPayloadOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -271,14 +303,38 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  final case class UpdatedPayload(name: String)
            |object UpdatedPayload {
            |
+           |  import io.circe._
+           |  import io.circe.generic.semiauto._
+           |  import org.http4s.{EntityEncoder, EntityDecoder}
+           |  import org.http4s.circe._
+           |  import cats.Applicative
+           |  import cats.effect.Sync
+           |  implicit val UpdatedPayloadEncoder: Encoder[UpdatedPayload] = deriveEncoder[UpdatedPayload]
+           |  implicit val UpdatedPayloadDecoder: Decoder[UpdatedPayload] = deriveDecoder[UpdatedPayload]
+           |  implicit def UpdatedPayloadEntityEncoder[F[_]:Applicative]: EntityEncoder[F, UpdatedPayload] = jsonEncoderOf[F, UpdatedPayload]
+           |  implicit def OptionUpdatedPayloadEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[UpdatedPayload]] = jsonEncoderOf[F, Option[UpdatedPayload]]
+           |  implicit def UpdatedPayloadEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdatedPayload] = jsonOf[F, UpdatedPayload]
            |
            |}
            |
            |}""".stripMargin
       )
+      // |  import io.circe._
+      //   |  import io.circe.generic.semiauto._
+      //   |  import org.http4s.{EntityEncoder, EntityDecoder}
+      //   |  import org.http4s.circe._
+      //   |  import cats.Applicative
+      //   |  import cats.effect.Sync
+      //   |  implicit val UpdateAnotherPayloadRequestEncoder: Encoder[UpdateAnotherPayloadRequest] = deriveEncoder[UpdateAnotherPayloadRequest]
+      //   |  implicit val UpdateAnotherPayloadRequestDecoder: Decoder[UpdateAnotherPayloadRequest] = deriveDecoder[UpdateAnotherPayloadRequest]
+      //   |  implicit def UpdateAnotherPayloadRequestEntityEncoder[F[_]:Applicative]: EntityEncoder[F, UpdateAnotherPayloadRequest] = jsonEncoderOf[F, UpdatedPayload]
+      //   |  implicit def OptionUpdateAnotherPayloadRequestEncoder[F[_]:Applicative]: EntityEncoder[F, Option[UpdateAnotherPayloadRequest]] = jsonEncoderOf[F, Option[UpdatedPayload]]
+      //   |  implicit def UpdateAnotherPayloadRequestdEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdateAnotherPayloadRequest] = jsonOf[F, UpdateAnotherPayloadRequest]
+
     }
 
     "when multiple responses with anonymous objects with default response" >> {
+      import Printer.avoid._
       interfaceDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -307,6 +363,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple responses and multiple error scenarios" >> {
+      import Printer.avoid._
       interfaceDefinition.print(payloadOpenApi.withPath(multipleResponses)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -326,6 +383,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "two operations with default response" >> {
+      import Printer.avoid._
       interfaceDefinition.print(payloadOpenApi.withPath(twoOperationsWithDefaultResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -358,6 +416,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when the failure response is empty" >> {
+      import Printer.avoid._
       interfaceDefinition.print(payloadOpenApi.withPath(emptyErrorResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -375,6 +434,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when multiple failure response are empty" >> {
+      import Printer.avoid._
       interfaceDefinition.print(payloadOpenApi.withPath(multipleEmptyErrorResponse)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
@@ -393,6 +453,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when a post operation is provided and operation id is not provided" >> {
+      import Printer.avoid._
       interfaceDefinition.print(
         petstoreOpenApi
           .withPath(
@@ -444,6 +505,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     import client.print._
     import client.http4s.print.implDefinition
     import client.http4s.print.Http4sSpecifics
+    import Printer.avoid._
     implicit val none: Http4sSpecifics = new Http4sSpecifics {
       def none[A]                                     = Printer.unit.contramap[A](_ => ())
       def applyMethod: Printer[(TraitName, ImplName)] = none
@@ -631,6 +693,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
   "http4s 0.20.x should able to print" >> {
     import client.http4s.print.impl
     import client.http4s.print.v20._
+    import Printer.avoid._
 
     "when a post operation is provided" >> {
       impl.print(
@@ -668,6 +731,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
   "http4s 0.18.x should able to print" >> {
     import client.http4s.print.impl
     import client.http4s.print.v18._
+    import Printer.avoid._
 
     "when a post operation is provided" >> {
       impl.print(PackageName("petstore") -> petstoreOpenApi.withPath(mediaTypeReferences)) must ===(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -92,7 +92,23 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}""".stripMargin
       )
     }
+  }
 
+  "circe encoders/decoders should able to print empty" >> {
+    import client.http4s.circe._
+    val printer = implicitly[Printer[Codecs[JsonSchemaF.Fixed]]]
+    "when a basic type is provided " >> {
+      printer.print(Codecs("Bars", Fixed.string())) must ===(
+        """|object Bars {
+           |}""".stripMargin
+      )
+    }
+    "when a reference is provided " >> {
+      printer.print(Codecs("Bars", Fixed.reference("Foo"))) must ===(
+        """|object Bars {
+           |}""".stripMargin
+      )
+    }
   }
 
   "Client trait should able to print" >> {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -96,6 +96,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  import org.http4s.circe._
            |  import cats.Applicative
            |  import cats.effect.Sync
+           |  implicit val ColorDecoder: Decoder[Color] = Decoder.decodeString.emap {
+           |  case "Blue" => Blue.asRight
+           |  case "Red" => Red.asRight
+           |  case x => s"$x is not valid Color".asLeft
+           |}
            |  implicit def ColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Color] = jsonEncoderOf[F, Color]
            |  implicit def OptionColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Color]] = jsonEncoderOf[F, Option[Color]]
            |  implicit def ColorEntityDecoder[F[_]:Sync]: EntityDecoder[F, Color] = jsonOf[F, Color]


### PR DESCRIPTION
This PR contains the following features:

* Moves **encoder/decoder** to its own package
* Prints **encoder/decoder** to companion object.
* **Avoids** the creation of encoder/ decoder for **basic types**.
* Converts objects without properties to `io.circe.Json`
* Creates **reusable printers** (e.g. objectDef, caseClassWithCodecsDef)
* Prints **encoders/decoders** for anonymous objects.
* Prints **encoders/decoders** for **Enums**.

This is a continuation of the following previous PRs:
- https://github.com/higherkindness/skeuomorph/pull/102
- https://github.com/higherkindness/skeuomorph/pull/97
- https://github.com/higherkindness/skeuomorph/pull/90
- https://github.com/higherkindness/skeuomorph/pull/81

You can find, the objectives for all these PRs here: https://github.com/47deg/marlow/issues/188
> Generating http4s client code based on a Open API specification using http4s v0.20 and 0.18 using circe to encode/decode.