### PR TITLE
Nested object

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -73,7 +73,7 @@ object JsonDecoders {
       def isObject: Decoder.Result[Unit] =
         validateType(c, "object") orElse
           propertyExists("properties") orElse
-          propertyExists("allOf")
+          propertyExists("allOf") orElse propertyExists("oneOf")
       for {
         _        <- isObject
         required <- c.downField("required").as[Option[List[String]]]

--- a/src/main/scala/higherkindness/skeuomorph/openapi/Optimize.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/Optimize.scala
@@ -16,6 +16,9 @@
 
 package higherkindness.skeuomorph.openapi
 import qq.droste._
+import cats.data.State
+import cats.implicits._
+
 object Optimize {
   def namedTypesTrans[T](name: String): Trans[JsonSchemaF, JsonSchemaF, T] = Trans {
     case JsonSchemaF.ObjectF(_, _) => JsonSchemaF.reference[T](name)
@@ -24,4 +27,64 @@ object Optimize {
   }
 
   def namedTypes[T: Basis[JsonSchemaF, ?]](name: String): T => T = scheme.cata(namedTypesTrans(name).algebra)
+
+  type NestedTypesState[T, O] = State[(Map[String, T], Long), O]
+
+  def nestedTypesTrans[T: Basis[JsonSchemaF, ?]]: TransM[NestedTypesState[T, ?], JsonSchemaF, JsonSchemaF, T] =
+    TransM {
+      case JsonSchemaF.ArrayF(x) if isNestedType(x) =>
+        extractNestedTypes("AnonymousObject", x).map { case (n, t) => JsonSchemaF.ArrayF(namedTypes(n).apply(t)) }
+
+      case JsonSchemaF.ObjectF(fields, required) =>
+        fields
+          .traverse[NestedTypesState[T, ?], JsonSchemaF.Property[T]] {
+            case p if (isNestedType(p.tpe)) =>
+              extractNestedTypes(p.name.capitalize, p.tpe).map {
+                case (n, t) => p.copy(tpe = namedTypes[T](n).apply(t))
+              }
+            case p => State.pure(p)
+          }
+          .map(JsonSchemaF.ObjectF(_, required))
+
+      case other => State.pure(other)
+    }
+
+  def nestedTypes[T: Basis[JsonSchemaF, ?]]: T => NestedTypesState[T, T] =
+    scheme.anaM(nestedTypesTrans.coalgebra)
+
+  private def isNestedType[T: Basis[JsonSchemaF, ?]](t: T): Boolean = {
+    import JsonSchemaF._
+    val algebra: Algebra[JsonSchemaF, Boolean] = Algebra {
+      case ObjectF(properties, _) if properties.nonEmpty => true
+      case EnumF(_)                                      => true
+      case _                                             => false
+    }
+    scheme.cata(algebra).apply(t)
+  }
+
+  private def extractNestedTypes[T: Basis[JsonSchemaF, ?]](name: String, tpe: T): NestedTypesState[T, (String, T)] = {
+    def inc: NestedTypesState[T, Unit] = State.modify { case (x, y) => (x -> (y + 1)) }
+    def addType(items: (String, T)): NestedTypesState[T, Unit] = State.modify {
+      case (x, y) => (x + items) -> y
+    }
+    def nameWith(i: Long): String = s"${name}$i"
+    def currentName: NestedTypesState[T, String] = State.inspect {
+      case (_, 0) => name
+      case (_, i) => nameWith(i)
+    }
+    def isFreeName: NestedTypesState[T, Boolean] = State.inspect {
+      case (x, 0) => x.get(name).isEmpty
+      case (x, i) => x.get(nameWith(i)).isEmpty
+    }
+    def findName: NestedTypesState[T, String] = isFreeName.flatMap {
+      case true  => currentName
+      case false => inc.flatMap(_ => findName)
+    }
+    for {
+      newType <- nestedTypes.apply(tpe)
+      newName <- findName
+      _       <- addType(newName -> newType)
+    } yield newName -> newType
+  }
+
 }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -38,7 +38,7 @@ package object circe {
     List("io.circe._", "io.circe.generic.semiauto._").map(PackageName.apply) ++ http4sPackages
 
   private val enumPackages = http4sPackages ++
-    List("cats.implicits._").map(PackageName.apply)
+    List("cats._", "cats.implicits._", "io.circe._").map(PackageName.apply)
 
   private def codecsTypes[T](name: String): ((String, Tpe[T]), (String, Tpe[T])) = {
     val tpe = Tpe[T](name)

--- a/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
@@ -100,6 +100,20 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
         )(obj("foo1" -> Fixed.reference("Foo1"))()))
     }
 
+    "when there are multiple level of nested objects when than alpha characters are the same" >> {
+      nestedTypesFrom(
+        obj(
+          "foo" ->
+            obj("foo1" ->
+              obj("foo" ->
+                obj("foo" -> Fixed.string())())())())()) must ===(
+        expectedTypes(
+          "Foo"  -> obj("foo"  -> Fixed.string())(),
+          "Foo1" -> obj("foo"  -> Fixed.reference("Foo"))(),
+          "Foo2" -> obj("foo1" -> Fixed.reference("Foo1"))()
+        )(obj("foo" -> Fixed.reference("Foo2"))()))
+    }
+
     "when there are multiple level of nested object of different types" >> {
       nestedTypesFrom(
         obj(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
@@ -28,7 +28,8 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
     x._1 -> y
   }
 
-  def expectedTypes[T: Basis[JsonSchemaF, ?]](d: (String, T)*)(t: T) = d.toMap -> t
+  def expectedTypes[T: Basis[JsonSchemaF, ?]](d: (String, T)*)(t: T) =
+    d.toMap -> t
 
   "basic types should not change" >> {
     "when integer is provided" >> {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.skeuomorph.openapi
+
+class NestedObjectSpecification extends org.specs2.mutable.Specification {
+  import JsonSchemaF.Fixed
+  import Optimize._
+  import cats.implicits._
+  import qq.droste._
+  import helpers._
+
+  def nestedTypesFrom[T: Basis[JsonSchemaF, ?]](t: T, map: Map[String, T] = Map.empty[String, T]) = {
+    val (x, y) = nestedTypes.apply(t).run(map -> 0).value
+    x._1 -> y
+  }
+
+  def expectedTypes[T: Basis[JsonSchemaF, ?]](d: (String, T)*)(t: T) = d.toMap -> t
+
+  "basic types should not change" >> {
+    "when integer is provided" >> {
+      nestedTypesFrom(Fixed.integer()) must ===(expectedTypes()(Fixed.integer()))
+    }
+    "when reference is provided" >> {
+      nestedTypesFrom(Fixed.reference("Foo")) must ===(expectedTypes()(Fixed.reference("Foo")))
+    }
+  }
+
+  "complex types should remove nested objects" >> {
+    "when an array is provided in the first level" >> {
+      val nestedObject = obj("foo" -> Fixed.string())("foo")
+      nestedTypesFrom(Fixed.array(nestedObject)) must ===(
+        expectedTypes("AnonymousObject" -> nestedObject)(Fixed.array(Fixed.reference("AnonymousObject"))))
+    }
+
+    "when an object is nested inside another object " >> {
+      val nestedObject = obj("name" -> Fixed.string(), "password" -> Fixed.password())("name")
+      nestedTypesFrom(obj("user" -> nestedObject, "another" -> Fixed.binary())("user")) must ===(
+        expectedTypes("User"     -> nestedObject)(
+          obj("user" -> Fixed.reference("User"), "another" -> Fixed.binary())("user"))
+      )
+    }
+
+    "when an object is nested inside an array that is nested inside another object" >> {
+      val nestedObject = obj("foo" -> Fixed.string())("foo")
+      nestedTypesFrom(obj("foo"         -> Fixed.array(nestedObject))()) must ===(
+        expectedTypes("AnonymousObject" -> nestedObject)(
+          obj("foo" -> Fixed.array(Fixed.reference("AnonymousObject")))()))
+    }
+
+    "when an enum is nested inside an object" >> {
+      val nestedEnum = Fixed.enum(List("Blue", "Green"))
+      nestedTypesFrom(obj("color" -> nestedEnum)()) must ===(
+        expectedTypes(
+          "Color" -> nestedEnum
+        )(
+          obj("color" -> Fixed.reference("Color"))()
+        )
+      )
+    }
+    "when an enum is nested inside an array" >> {
+      val nestedEnum = Fixed.enum(List("Blue", "Green"))
+      nestedTypesFrom(obj("colors" -> Fixed.array(nestedEnum))()) must ===(
+        expectedTypes(
+          "AnonymousObject" -> nestedEnum
+        )(
+          obj("colors" -> Fixed.array(Fixed.reference("AnonymousObject")))()
+        )
+      )
+    }
+
+    "when there are multiple level of nested objects" >> {
+      nestedTypesFrom(
+        obj(
+          "foo1" ->
+            obj(
+              "foo2" ->
+                obj("foo3" ->
+                  obj("foo4" ->
+                    obj("foo5" -> Fixed.string())())())())())()) must ===(
+        expectedTypes(
+          "Foo4" -> obj("foo5" -> Fixed.string())(),
+          "Foo3" -> obj("foo4" -> Fixed.reference("Foo4"))(),
+          "Foo2" -> obj("foo3" -> Fixed.reference("Foo3"))(),
+          "Foo1" -> obj("foo2" -> Fixed.reference("Foo2"))()
+        )(obj("foo1" -> Fixed.reference("Foo1"))()))
+    }
+
+    "when there are multiple level of nested object of different types" >> {
+      nestedTypesFrom(
+        obj(
+          "foo1" ->
+            Fixed.array(
+              obj("foo2" ->
+                Fixed.array(obj("foo3" ->
+                  Fixed.array(obj("foo4" ->
+                    Fixed.array(obj("foo5" -> Fixed.array(Fixed.string()))()))()))()))()))()) must ===(
+        expectedTypes(
+          "AnonymousObject3" -> obj("foo2" -> Fixed.array(Fixed.reference("AnonymousObject2")))(),
+          "AnonymousObject2" -> obj("foo3" -> Fixed.array(Fixed.reference("AnonymousObject1")))(),
+          "AnonymousObject1" -> obj("foo4" -> Fixed.array(Fixed.reference("AnonymousObject")))(),
+          "AnonymousObject"  -> obj("foo5" -> Fixed.array(Fixed.string()))()
+        )(obj("foo1" -> Fixed.array(Fixed.reference("AnonymousObject3")))()))
+    }
+  }
+  "when the name of the anonymous object exists already as a type" >> {
+    nestedTypesFrom(
+      obj("user" -> obj("name" -> Fixed.string())())(),
+      Map("User" -> Fixed.string())
+    ) must ===(
+      expectedTypes(
+        "User"  -> Fixed.string(),
+        "User1" -> obj("name" -> Fixed.string())()
+      )(obj("user" -> Fixed.reference("User1"))()))
+
+  }
+}

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
@@ -16,11 +16,14 @@
 
 package higherkindness.skeuomorph.openapi
 
+// import cats.implicits._
+
 class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification {
   import helpers._
   import schema._
   import JsonSchemaF.Fixed
   import OpenApi._
+
   "open api should extract nested object" >> {
     "when nested objects are defined in schemas" >> {
       extractNestedTypes(
@@ -34,6 +37,25 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
           .withSchema("Foos" -> Fixed.array(Fixed.reference("AnonymousObject")))
       )
     }
-    
+
+    "when nested objects are defined in request" >> {
+      extractNestedTypes(
+        openApi("name").withPath(
+          "foo" -> emptyItemObject
+            .withPut(
+              operation[JsonSchemaF.Fixed](
+                request("application/json" -> mediaType(obj("foo" -> Fixed.enum(List("1", "2")))())),
+                "200" -> response[JsonSchemaF.Fixed]("Null response")
+              )))) must ===(
+        openApi("name")
+          .withPath(
+            "foo" -> emptyItemObject
+              .withPut(operation[JsonSchemaF.Fixed](
+                request("application/json" -> mediaType(obj("foo" -> Fixed.reference("Foo"))())),
+                "200" -> response[JsonSchemaF.Fixed]("Null response")
+              )))
+          .withSchema("Foo" -> Fixed.enum(List("1", "2"))))
+    }
+
   }
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.skeuomorph.openapi
+
+class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification {
+  import helpers._
+  import schema._
+  import JsonSchemaF.Fixed
+  import OpenApi._
+  "open api should extract nested object" >> {
+    "when nested objects are defined in schemas" >> {
+      extractNestedTypes(
+        openApi("name")
+          .withSchema("Foo" -> obj("bar" -> obj("x" -> Fixed.string())())())
+          .withSchema("Foos" -> Fixed.array(obj("y" -> Fixed.integer())()))) must ===(
+        openApi("name")
+          .withSchema("Bar" -> obj("x" -> Fixed.string)())
+          .withSchema("Foo" -> obj("bar" -> Fixed.reference("Bar"))())
+          .withSchema("AnonymousObject" -> obj("y" -> Fixed.integer())())
+          .withSchema("Foos" -> Fixed.array(Fixed.reference("AnonymousObject")))
+      )
+    }
+    
+  }
+}

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
@@ -16,8 +16,6 @@
 
 package higherkindness.skeuomorph.openapi
 
-// import cats.implicits._
-
 class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification {
   import helpers._
   import schema._
@@ -57,5 +55,26 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
           .withSchema("Foo" -> Fixed.enum(List("1", "2"))))
     }
 
+    "when nested objects are defined in request" >> {
+      extractNestedTypes(
+        openApi("name").withPath(
+          "foo" -> emptyItemObject
+            .withGet(
+              operationWithResponses[JsonSchemaF.Fixed](
+                "200" -> response[JsonSchemaF.Fixed](
+                  "Response",
+                  "application/json" -> mediaType(obj("values" -> Fixed.array(obj("value" -> Fixed.integer())()))()))
+              )))) must ===(
+        openApi("name")
+          .withPath(
+            "foo" -> emptyItemObject
+              .withGet(
+                operationWithResponses[JsonSchemaF.Fixed]("200" -> response[JsonSchemaF.Fixed](
+                  "Response",
+                  "application/json" -> mediaType(obj("values" -> Fixed.array(Fixed.reference("AnonymousObject")))())))
+              ))
+          .withSchema("AnonymousObject" -> obj("value" -> Fixed.integer())())
+      )
+    }
   }
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -96,7 +96,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  import org.http4s.circe._
            |  import cats.Applicative
            |  import cats.effect.Sync
+           |  import cats._
            |  import cats.implicits._
+           |  import io.circe._
            |  implicit val ColorShow: Show[Color] = Show.show {
            |  case Blue => "Blue"
            |  case Red => "Red"


### PR DESCRIPTION
# Objective
You can find, the objectives for all these PRs here: https://github.com/47deg/marlow/issues/188
> Generating http4s client code based on a Open API specification using http4s v0.20 and 0.18 using circe to encode/decode.

# Problem
**Open api spec** is based on **Yaml/Json** to define types, this means that not all the types have a name. You can inline objects if you want to. However, this can create a problematic situation when the objects are nested inside the *Yaml/Json* tree. Let's look at an example when `Person` is inline inside a `Owner`. 

```yaml
   Owner:
      required:
        - person
      properties:
        address: 
          type: string
        person:
          type: object
          required:
           - name
           - surname
          properties:
            name:
              type: string
            surname:
              type: string
            age: 
              type: integer
```

However, when we generate code, we can create the following situations:
```scala
final case class Owner(address: Option[String], person: final case class Person(name: String, surname: String, age: Option[Int]))
```
As we can see this code is not valid *scala* code, then we need to figure out a way to extract these nested objects from the _json/yaml_ tree.  Ideally, we should try to generate the following code:

```scala
final case class Owner(address: Option[String], person: Person)
final case class Person(name: String, surname: String, age: Option[Int])
```
We need to apply this solution to the schemas itself (`T`) and to the `components`, `requestBody` and `responses` in the **OpenApi** Tree.

# Solution
In order to solve this, we have created the following **entry functions** to avoid the problem described above:
- For **Schemas** (check out`NestedObjectSpecification` for more details): 
```scala
def nestedTypes[T: Basis[JsonSchemaF, ?]]: T => NestedTypesState[T, T]
```
`NestedTypesState` is type used to accumulate the `(String, T)` we find (e.g. `Person`) and with a counter to avoid duplicated types (_anonymous_ or not). At the end of the execution of `NestedTypesState` we should incorporate all the new schemas found into `#/components/schemas`.
- For **OpenApi** (check out `OpenApiNestedObjectSpecification` for more details):
```scala
def extractNestedTypes[T: Basis[JsonSchemaF, ?]](openApi: OpenApi[T]): OpenApi[T]
```

# Previous PRs
- https://github.com/higherkindness/skeuomorph/pull/109
- https://github.com/higherkindness/skeuomorph/pull/102
- https://github.com/higherkindness/skeuomorph/pull/97
- https://github.com/higherkindness/skeuomorph/pull/90
- https://github.com/higherkindness/skeuomorph/pull/81


