### PR TITLE
Removes the optionality in Coproducts

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/mu/Optimize.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Optimize.scala
@@ -52,14 +52,26 @@ object Optimize {
     case other => other
   }
 
+  def nestedOptionInCoproductsTrans[T](implicit T: Basis[MuF, T]): Trans[MuF, MuF, T] = Trans {
+    case TCoproduct(nel) => TCoproduct(nel.map(toRequiredTypes))
+    case other           => other
+  }
+
+  def toRequiredTypesTrans[T]: Trans[MuF, MuF, T] = Trans {
+    case TOption(value) => TRequired(value)
+    case other          => other
+  }
+
   def namedTypesTrans[T]: Trans[MuF, MuF, T] = Trans {
     case TProduct(name, _) => TNamedType[T](name)
     case TSum(name, _)     => TNamedType[T](name)
     case other             => other
   }
 
-  def namedTypes[T: Basis[MuF, ?]]: T => T       = scheme.cata(namedTypesTrans.algebra)
-  def nestedNamedTypes[T: Basis[MuF, ?]]: T => T = scheme.cata(nestedNamedTypesTrans.algebra)
+  def namedTypes[T: Basis[MuF, ?]]: T => T              = scheme.cata(namedTypesTrans.algebra)
+  def nestedNamedTypes[T: Basis[MuF, ?]]: T => T        = scheme.cata(nestedNamedTypesTrans.algebra)
+  def toRequiredTypes[T: Basis[MuF, ?]]: T => T         = scheme.cata(toRequiredTypesTrans.algebra)
+  def nestedOptionInCoproduct[T: Basis[MuF, ?]]: T => T = scheme.cata(nestedOptionInCoproductsTrans.algebra)
 
   /**
    * micro-optimization to convert known coproducts to named types

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -24,6 +24,7 @@ import higherkindness.skeuomorph.catz.contrib.Decidable._
 import higherkindness.skeuomorph.mu.CompressionType.{Gzip, Identity}
 import higherkindness.skeuomorph.mu.MuF.{string => _, _}
 import higherkindness.skeuomorph.mu.Optimize.namedTypes
+import higherkindness.skeuomorph.mu.Optimize.nestedOptionInCoproduct
 import higherkindness.skeuomorph.mu.SerializationType._
 import qq.droste._
 
@@ -198,7 +199,7 @@ object print {
       sepBy(option, lineFeed),
       sepBy(depImport, lineFeed) >* newLine >* newLine,
       konst("object ") *< string >* konst(" { ") >* newLine >* newLine,
-      sepBy(schema, lineFeed) >* newLine,
+      sepBy(Printer(nestedOptionInCoproduct[T] >>> schema.print), lineFeed) >* newLine,
       sepBy(service, doubleLineFeed) >* (newLine >* newLine >* konst("}"))
     ).contramapN(protoTuple)
   }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -74,7 +74,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |@message final case class Book(isbn: Long, title: String, author: List[Option[Author]], binding_type: Option[BindingType], rating: Option[Rating])
       |@message final case class GetBookRequest(isbn: Long)
       |@message final case class GetBookViaAuthor(author: Option[Author])
-      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Cop[Long :: Int :: String :: Option[Book]:: TNil])
+      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Cop[Long :: Int :: String :: Book :: TNil])
       |
       |sealed trait Genre
       |object Genre {


### PR DESCRIPTION
This PR fixes #113 

It converts the `TOption` values within `TCoproduct` into `TRequired`.