### PR TITLE
Normalize and more support for open api spec

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -64,10 +64,7 @@ object JsonDecoders {
       } yield JsonSchemaF.enum[A](values).embed)
 
   private def sumJsonSchemaDecoder[A: Embed[JsonSchemaF, ?]]: Decoder[A] =
-    Decoder.instance(c =>
-      for {
-        values <- c.downField("oneOf").as[List[A]]
-      } yield JsonSchemaF.sum[A](values).embed)
+    Decoder.instance(_.downField("oneOf").as[List[A]].map(JsonSchemaF.sum[A](_).embed))
 
   private def objectJsonSchemaDecoder[A: Embed[JsonSchemaF, ?]]: Decoder[A] =
     Decoder.instance { c =>

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -280,16 +280,22 @@ object JsonDecoders {
               servers.getOrElse(List.empty))))
 
   implicit def componentsDecoder[A: Decoder]: Decoder[Components[A]] =
-    Decoder.forProduct3(
+    Decoder.forProduct4(
       "schemas",
       "responses",
-      "requestBodies"
+      "requestBodies",
+      "parameters"
     )(
       (
           schemas: Option[Map[String, A]],
           responses: Option[Map[String, Either[Response[A], Reference]]],
-          requestBodies: Option[Map[String, Either[Request[A], Reference]]]) =>
-        Components(schemas.getOrElse(Map.empty), responses.getOrElse(Map.empty), requestBodies.getOrElse(Map.empty)))
+          requestBodies: Option[Map[String, Either[Request[A], Reference]]],
+          parameters: Option[Map[String, Either[Parameter[A], Reference]]]) =>
+        Components(
+          schemas.getOrElse(Map.empty),
+          responses.getOrElse(Map.empty),
+          requestBodies.getOrElse(Map.empty),
+          parameters.getOrElse(Map.empty)))
 
   implicit def openApiDecoder[A: Decoder]: Decoder[OpenApi[A]] =
     Decoder.forProduct7(

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -238,7 +238,7 @@ object JsonDecoders {
         ))
 
   implicit def itemObjectDecoder[A: Decoder]: Decoder[Path.ItemObject[A]] =
-    Decoder.forProduct12(
+    Decoder.forProduct13(
       "ref",
       "summary",
       "description",
@@ -250,7 +250,8 @@ object JsonDecoders {
       "head",
       "patch",
       "trace",
-      "servers")(
+      "servers",
+      "parameters")(
       (
           (
               ref: Option[String], // $ref
@@ -264,7 +265,9 @@ object JsonDecoders {
               head: Option[Path.Operation[A]],
               patch: Option[Path.Operation[A]],
               trace: Option[Path.Operation[A]],
-              servers: Option[List[Server]]) =>
+              servers: Option[List[Server]],
+              parameters: Option[List[Either[Parameter[A], Reference]]]
+          ) =>
             Path.ItemObject(
               ref,
               summary,
@@ -277,7 +280,8 @@ object JsonDecoders {
               head,
               patch,
               trace,
-              servers.getOrElse(List.empty))))
+              servers.getOrElse(List.empty),
+              parameters.getOrElse(List.empty))))
 
   implicit def componentsDecoder[A: Decoder]: Decoder[Components[A]] =
     Decoder.forProduct4(

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
@@ -163,7 +163,7 @@ object JsonEncoders {
     }
 
   implicit def itemObjectEncoder[A: Encoder]: Encoder[Path.ItemObject[A]] =
-    Encoder.forProduct12(
+    Encoder.forProduct13(
       "ref",
       "summary",
       "description",
@@ -175,9 +175,23 @@ object JsonEncoders {
       "head",
       "patch",
       "trace",
-      "servers"
+      "servers",
+      "parameters"
     ) { i =>
-      (i.ref, i.summary, i.description, i.get, i.put, i.post, i.delete, i.options, i.head, i.patch, i.trace, i.servers)
+      (
+        i.ref,
+        i.summary,
+        i.description,
+        i.get,
+        i.put,
+        i.post,
+        i.delete,
+        i.options,
+        i.head,
+        i.patch,
+        i.trace,
+        i.servers,
+        i.parameters)
     }
 
   implicit def componentsEncoder[A: Encoder]: Encoder[Components[A]] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
@@ -181,11 +181,12 @@ object JsonEncoders {
     }
 
   implicit def componentsEncoder[A: Encoder]: Encoder[Components[A]] =
-    Encoder.forProduct3(
+    Encoder.forProduct4(
       "schemas",
       "responses",
-      "requestBodies"
-    )(c => (c.schemas, c.responses, c.requestBodies))
+      "requestBodies",
+      "parameters"
+    )(c => (c.schemas, c.responses, c.requestBodies, c.parameters))
 
   implicit def openApiEncoder[A: Encoder]: Encoder[OpenApi[A]] =
     Encoder.forProduct7(

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
@@ -177,22 +177,7 @@ object JsonEncoders {
       "trace",
       "servers",
       "parameters"
-    ) { i =>
-      (
-        i.ref,
-        i.summary,
-        i.description,
-        i.get,
-        i.put,
-        i.post,
-        i.delete,
-        i.options,
-        i.head,
-        i.patch,
-        i.trace,
-        i.servers,
-        i.parameters)
-    }
+    ) { Path.ItemObject.unapply(_).get }
 
   implicit def componentsEncoder[A: Encoder]: Encoder[Components[A]] =
     Encoder.forProduct4(

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonSchema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonSchema.scala
@@ -42,6 +42,7 @@ object JsonSchemaF {
   final case class ObjectF[A](properties: List[Property[A]], required: List[String]) extends JsonSchemaF[A]
   final case class ArrayF[A](values: A)                                              extends JsonSchemaF[A]
   final case class EnumF[A](cases: List[String])                                     extends JsonSchemaF[A]
+  final case class SumF[A](cases: List[A])                                           extends JsonSchemaF[A]
   final case class ReferenceF[A](ref: String)                                        extends JsonSchemaF[A]
 
   def integer[T](): JsonSchemaF[T]  = IntegerF()
@@ -59,6 +60,7 @@ object JsonSchemaF {
     ObjectF(properties, required)
   def array[T](values: T): JsonSchemaF[T]          = ArrayF(values)
   def enum[T](cases: List[String]): JsonSchemaF[T] = EnumF(cases)
+  def sum[T](cases: List[T]): JsonSchemaF[T]       = SumF(cases)
   def reference[T](ref: String): JsonSchemaF[T]    = ReferenceF[T](ref)
 
   type Fixed = Fix[JsonSchemaF]
@@ -77,9 +79,10 @@ object JsonSchemaF {
     def password[A](): JsonSchemaF.Fixed = Fix(JsonSchemaF.password())
     def `object`(properties: List[(String, JsonSchemaF.Fixed)], required: List[String]): JsonSchemaF.Fixed =
       Fix(JsonSchemaF.`object`(properties.map(JsonSchemaF.Property.apply[JsonSchemaF.Fixed] _ tupled), required))
-    def array(value: JsonSchemaF.Fixed): JsonSchemaF.Fixed = Fix(JsonSchemaF.array(value))
-    def enum(value: List[String]): JsonSchemaF.Fixed       = Fix(JsonSchemaF.enum(value))
-    def reference(value: String): JsonSchemaF.Fixed        = Fix(JsonSchemaF.reference(value))
+    def array(value: JsonSchemaF.Fixed): JsonSchemaF.Fixed        = Fix(JsonSchemaF.array(value))
+    def enum(value: List[String]): JsonSchemaF.Fixed              = Fix(JsonSchemaF.enum(value))
+    def sum[A](value: List[JsonSchemaF.Fixed]): JsonSchemaF.Fixed = Fix(JsonSchemaF.sum(value))
+    def reference(value: String): JsonSchemaF.Fixed               = Fix(JsonSchemaF.reference(value))
   }
 
   private def jsonType(value: String, attr: (String, Json)*): Json =
@@ -113,6 +116,8 @@ object JsonSchemaF {
       )
     case EnumF(cases) =>
       jsonType("string", "enum" -> Json.fromValues(cases.map(Json.fromString)))
+    case SumF(cases) =>
+      Json.obj("oneOf" -> Json.arr(cases: _*))
     case ReferenceF(value) =>
       Json.obj(
         s"$$ref" -> Json.fromString(value)
@@ -139,6 +144,7 @@ object JsonSchemaF {
     case (ObjectF(p1, r1), ObjectF(p2, r2)) => p1 === p2 && r1 === r2
     case (ArrayF(v1), ArrayF(v2))           => v1 === v2
     case (EnumF(c1), EnumF(c2))             => c1 === c2
+    case (SumF(c1), SumF(c2))               => c1 === c2
     case (ReferenceF(r1), ReferenceF(r2))   => r1 === r2
     case _                                  => false
   }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/Optimize.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/Optimize.scala
@@ -39,7 +39,7 @@ object Optimize {
         fields
           .traverse[NestedTypesState[T, ?], JsonSchemaF.Property[T]] {
             case p if (isNestedType(p.tpe)) =>
-              extractNestedTypes(p.name.capitalize, p.tpe).map {
+              extractNestedTypes(p.name.capitalize, p.tpe).map { //TODO Maybe we should normalize
                 case (n, t) => p.copy(tpe = namedTypes[T](n).apply(t))
               }
             case p => State.pure(p)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -124,8 +124,8 @@ package object circe {
       (
         κ("Encoder.forProduct") *< string >* κ("("),
         sepBy(κ("\"") *< string >* κ("\""), ", ") >* κ(")"),
-        κ("(t => (") *< sepBy(κ("t.") *< string, ", ") >* κ("))")
-      ).contramapN(x => (x.length.toString, x, x.map(x => decapitalize(normalize(x))))))
+        κ("(t => (") *< sepBy(κ("t.") *< show[Var], ", ") >* κ("))")
+      ).contramapN(x => (x.length.toString, x, x.map(Var.apply))))
       .contramap(x => (x._1, x._2, x._3))
 
   def forProductCirceDecoder[T: Basis[JsonSchemaF, ?]]: Printer[(String, Tpe[T], List[String])] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -44,6 +44,8 @@ package object circe {
     val tpe = Tpe[T](name)
     (name -> tpe) -> (s"Option${name}" -> tpe.copy(required = false))
   }
+  protected def isIdentifier: String => Boolean =
+    field => field.headOption.exists(x => x.isLetter && x.isLower) && field.forall(_.isLetterOrDigit)
 
   implicit def circeCodecsPrinter[T: Basis[JsonSchemaF, ?]]: Printer[Codecs] =
     (
@@ -55,9 +57,7 @@ package object circe {
       space *< space *< entityEncoder[T] >* newLine,
       space *< space *< entityDecoder[T] >* newLine)
       .contramapN {
-        case CaseClassCodecs(name, fields)
-            if fields.forall(field =>
-              (field.headOption.exists(x => x.isLetter && x.isLower) && field.forall(_.isLetterOrDigit))) =>
+        case CaseClassCodecs(name, fields) if fields.forall(isIdentifier) =>
           val (default, optionType) = codecsTypes[T](name)
           (
             packages,

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -66,14 +66,11 @@ package object circe {
             x -> fields
           })
           (packages, none, withFields.asRight.asLeft, withFields.asRight.asLeft, default, optionType, default)
-        case ListCodecs(name) =>
-          val (default, optionType) = codecsTypes[T](name)
-          (http4sPackages, none, none.asLeft.asLeft, none.asLeft.asLeft, default, optionType, default)
         case EnumCodecs(name, values) =>
           val (default, optionType) = codecsTypes[T](name)
           (
             enumPackages,
-            (name -> name, values.map(x => x -> x)).some,
+            (name -> name, values.map(x => normalize(x) -> x)).some,
             name.asRight,
             (name, values).asRight,
             default,
@@ -110,7 +107,9 @@ package object circe {
             "\n"
           ) >* newLine,
         κ("""  case x => s"$x is not valid """) *< string >* κ("""".asLeft""") *< newLine *< κ("}") *< newLine
-      ).contramapN(x => flip(second(x)(_.map(x => x -> x))))).contramap { case (x, xs) => (x, Tpe[T](x), x -> xs) }
+      ).contramapN(x => flip(second(x)(_.map(x => x -> normalize(x)))))).contramap {
+      case (x, xs) => (x, Tpe[T](x), x -> xs)
+    }
 
   def circeDecoder[T: Basis[JsonSchemaF, ?]]: Printer[(String, Tpe[T])] =
     decoderDef(κ("deriveDecoder[") *< tpe[T] >* κ("]"))

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -189,7 +189,7 @@ object print {
   def queryParameter[T]: Printer[Parameter.Query[T]] =
     (space *< string >* space, κ("(\"") *< divBy(string, κ("\", "), string) >* κ(")")).contramapN { q =>
       def op(x: Parameter.Query[T]): String = if (x.required) "+?" else "+??"
-      (op(q), q.name -> q.name)
+      (op(q), q.name -> decapitalize(normalize(q.name)))
     }
 
   def httpPath[T]: Printer[HttpPath] =
@@ -199,7 +199,7 @@ object print {
         .filter(_.nonEmpty)
         .map { s =>
           if (s.startsWith("{") && s.endsWith("}"))
-            s"${s.tail.init}.show"
+            s"${decapitalize(normalize(s.tail.init))}.show"
           else
             "\"" + s + "\""
         }
@@ -240,7 +240,7 @@ object print {
         )
 
       def withBody: Printer[String] =
-        κ(".withEntity(") *< string >* κ(")")
+        (κ(".withEntity(") *< string >* κ(")")).contramap(x => decapitalize(normalize(x)))
     }
   }
   object v18 {
@@ -255,7 +255,7 @@ object print {
         )
 
       def withBody: Printer[String] =
-        κ(".withBody(") *< string >* κ(")")
+        (κ(".withBody(") *< string >* κ(")")).contramap(x => decapitalize(normalize(x)))
     }
   }
 }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -54,6 +54,8 @@ object print {
     "implicit def optionListEntityDecoder[T: Decoder]: EntityDecoder[F, Option[List[T]]] = jsonOf[F, Option[List[T]]]")
   val timeQueryParamEncoder: Printer[Unit] =
     κ("localDateTimeQueryEncoder: QueryParamEncoder[java.time.LocalDateTime], localDateQueryEncoder: QueryParamEncoder[java.time.LocalDate]")
+  val showQueryParamEncoder: Printer[Unit] =
+    κ("implicit def showQueryParameter[T: Show]: QueryParamEncoder[T] = QueryParamEncoder.stringQueryParamEncoder.contramap(_.show)")
   type ImplDef[T] = (TraitName, TraitName, List[PackageName], List[Http.Operation[T]], (TraitName, ImplName))
   def implDefinition[T: Basis[JsonSchemaF, ?]](
       implicit http4sSpecifics: Http4sSpecifics,
@@ -66,7 +68,8 @@ object print {
         twoSpaces *< twoSpaces *< listEnconderPrinter *< newLine *<
         twoSpaces *< twoSpaces *< listDecoderPrinter *< newLine *<
         twoSpaces *< twoSpaces *< optionListEncoderPrinter *< newLine *<
-        twoSpaces *< twoSpaces *< optionListDecoderPrinter *< newLine,
+        twoSpaces *< twoSpaces *< optionListDecoderPrinter *< newLine *<
+        twoSpaces *< twoSpaces *< showQueryParamEncoder *< newLine,
       sepBy(twoSpaces *< methodImpl(http4sSpecifics.withBody), "\n") >* newLine *< κ("  }") *< newLine,
       http4sSpecifics.applyMethod).contramapN(identity)).contramap { x =>
       (
@@ -204,6 +207,7 @@ object print {
     }
 
   private val packages = List(
+    "cats._",
     "cats.effect._",
     "cats.implicits._",
     "io.circe._",

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -37,10 +37,10 @@ object print {
     (sepBy(importDef, "\n") >* newLine, implDefinition[T]).contramapN {
       case (packageName, openApi) =>
         (
-          packages ++ List(
+          packages ++ (List(
             s"${packageName.show}.${TraitName(openApi).show}",
             s"${packageName.show}.models._"
-          ).map(PackageName.apply),
+          ) ++ sumTypes(openApi).map(x => s"$x._")).map(PackageName.apply),
           openApi)
     }
 
@@ -73,7 +73,7 @@ object print {
       sepBy(twoSpaces *< methodImpl, "\n") >* newLine *< κ("  }") *< newLine,
       http4sSpecifics.applyMethod).contramapN(identity)).contramap { x =>
       (
-        ImplName(x).show,
+        (ImplName(x).show, none),
         List.empty,
         (
           TraitName(x),

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -196,10 +196,10 @@ object print {
     ).contramapN { operationTuple[T] }
 
   private def itemObjectTuple[T](
-      x: String,
+      thePath: String,
       itemObject: ItemObject[T],
       components: Components[T]): List[OperationWithPath[T]] = {
-    val path = HttpPath.apply(x)
+    val path = HttpPath.apply(thePath)
 
     def findParameter(name: String): Option[Parameter[T]] =
       components.parameters.get(name).flatMap(_.fold(_.some, parameterFrom))
@@ -215,7 +215,7 @@ object print {
         path,
         operation.description,
         OperationId((verb, path, operation)),
-        operation.parameters.flatMap(_.fold(_.some, parameterFrom)),
+        (itemObject.parameters ++ operation.parameters).flatMap(_.fold(_.some, parameterFrom)),
         operation.requestBody,
         operation.responses
       )

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -215,7 +215,9 @@ object print {
         path,
         operation.description,
         OperationId((verb, path, operation)),
-        (itemObject.parameters ++ operation.parameters).flatMap(_.fold(_.some, parameterFrom)),
+        (itemObject.parameters ++ operation.parameters)
+          .flatMap(_.fold(_.some, parameterFrom))
+          .distinct,
         operation.requestBody,
         operation.responses
       )

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -425,7 +425,7 @@ object print {
           (
             ops.map(operation => operation.operationId -> operation.requestBody),
             ops.map(operation => operation.operationId -> operation.responses),
-            params.headOption.map(_ => (parametersPackage, List.empty, params))
+            params.headOption.map(_ => ((parametersPackage, none), List.empty, params))
           )
       }
 
@@ -440,7 +440,7 @@ object print {
       TraitName,
       TraitName,
       List[Http.Operation[T]],
-      (String, List[PackageName], (List[Http.Operation[T]], List[Parameter[T]]))) = {
+      ((String, Option[String]), List[PackageName], (List[Http.Operation[T]], List[Parameter[T]]))) = {
     val traitName = TraitName(openApi)
     val (a, b, c, d) = un(second(duplicate(toOperationsWithPath(traitName, openApi.paths, componentsFrom(openApi)))) {
       case (a, b) => (a, (traitName, b))
@@ -453,7 +453,7 @@ object print {
       a,
       b,
       c,
-      (d._1.show, List.empty, (d._2, parameters)))
+      ((d._1.show, none), List.empty, (d._2, parameters)))
   }
 
   def interfaceDefinition[T: Basis[JsonSchemaF, ?]](implicit codecs: Printer[Codecs]): Printer[OpenApi[T]] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -87,14 +87,14 @@ object print {
     implicit val implNameShow: Show[ImplName]   = Show.show(_.value)
   }
 
-  final case class OperationId(value: String) extends AnyVal
+  final case class OperationId private (value: String) extends AnyVal
 
   object OperationId {
 
     def apply[T](operationWithPath: OperationWithPath[T]): OperationId =
-      OperationId(operationWithPath._3.operationId.getOrElse {
+      OperationId(decapitalize(normalize(operationWithPath._3.operationId.getOrElse {
         s"${HttpVerb.methodFrom(operationWithPath._1)}${operationWithPath._2.method}"
-      })
+      })))
 
     implicit val operationIdShow: Show[OperationId] = Show.show(_.value)
   }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -168,10 +168,9 @@ object print {
       request: Request[T]): Option[VarWithType[T]] =
     jsonFrom(request.content)
       .flatMap(
-        x =>
-          x.schema.map(x =>
-            VarWithType.tpe[T](
-              Tpe(x, request.required, request.description.getOrElse(defaultRequestName(operationId)), Nil))))
+        _.schema.map(x =>
+          VarWithType.tpe[T](
+            Tpe(x, request.required, request.description.getOrElse(defaultRequestName(operationId)), Nil))))
 
   private def referenceTuple[T: Basis[JsonSchemaF, ?]](reference: Reference): Option[VarWithType[T]] =
     reference.ref match {

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -190,7 +190,7 @@ object print {
       body >* newLine *< κ("}")
     ).contramap { case (x, y, z) => (x -> y, z) }
 
-  def normalize(value: String): String = value.split(" ").map(_.filter(_.isLetter).capitalize).mkString
+  def normalize(value: String): String = value.split("[ _-]").map(_.filter(_.isLetterOrDigit).capitalize).mkString
 
   def divBy[A, B](p1: Printer[A], sep: Printer[Unit], p2: Printer[B]): Printer[(A, B)] =
     (p1, sep, p2).contramapN[(A, B)] { case (x, y) => (x, (), y) }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -83,23 +83,23 @@ object print {
 
   def isBasicType[T: Basis[JsonSchemaF, ?]](t: T): Boolean = {
     import JsonSchemaF._
-    val algebra: Algebra[JsonSchemaF, Boolean] = Algebra {
+    import qq.droste.syntax.project._
+    t.project match {
       case ObjectF(p, _) => p.isEmpty
       case EnumF(_)      => false
       case ArrayF(_)     => false
       case ReferenceF(_) => false
       case _             => true
     }
-    scheme.cata(algebra).apply(t)
   }
 
   def isArray[T: Basis[JsonSchemaF, ?]](t: T): Boolean = {
     import JsonSchemaF._
-    val algebra: Algebra[JsonSchemaF, Boolean] = Algebra {
+    import qq.droste.syntax.project._
+    t.project match {
       case ArrayF(_) => true
       case _         => false
     }
-    scheme.cata(algebra).apply(t)
   }
 
   sealed trait Codecs

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -34,7 +34,7 @@ object print {
   def schemaWithName[T: Basis[JsonSchemaF, ?]](implicit codecs: Printer[Codecs]): Printer[(String, T)] = Printer {
     case (name, t) if (isBasicType(t)) => typeAliasDef(schema[T]()).print((normalize(name), t, none))
     case (name, t) if (isArray(t)) =>
-      typeAliasDef(schema[T]()).print((normalize(name), t, (List.empty, ListCodecs(name)).some))
+      typeAliasDef(schema[T]()).print((normalize(name), t, none))
     case (name, t) => schema[T](normalize(name).some).print(t)
   }
 
@@ -103,7 +103,6 @@ object print {
 
   sealed trait Codecs
   final case class CaseClassCodecs(name: String, fields: List[String]) extends Codecs
-  final case class ListCodecs(name: String)                            extends Codecs
   final case class EnumCodecs(name: String, values: List[String])      extends Codecs
 
   final case class Tpe[T](tpe: Either[String, T], required: Boolean, description: String)
@@ -144,7 +143,7 @@ object print {
     }
 
   private def caseObjectDef: Printer[(String, String)] =
-    (κ("final case object ") *< string >* κ(" extends "), string).contramapN(identity)
+    (κ("final case object ") *< string >* κ(" extends "), string).contramapN { case (x, y) => (normalize(x), y) }
 
   private def sealedTraitCompanionObjectDef(
       implicit codecs: Printer[Codecs]): Printer[(List[(String, String)], Codecs)] =

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -74,11 +74,11 @@ object print {
 
         case (ObjectF(properties, _), _) if (properties.isEmpty) => "io.circe.Json"
         case (ArrayF(x), _)                                      => listDef.print(x)
-        case (EnumF(fields), Some(name)) =>
-          sealedTraitDef.print(name -> fields)
-        case (ReferenceF(schemasRegex(ref)), _)    => normalize(ref)
-        case (ReferenceF(parametersRegex(ref)), _) => normalize(ref)
-        case (ReferenceF(ref), _)                  => normalize(ref)
+        case (EnumF(fields), Some(name))                         => sealedTraitDef.print(name -> fields)
+        case (SumF(cases), Some(name))                           => s"type $name = " + cases.mkString(" :+: ") + " :+: CNil"
+        case (ReferenceF(schemasRegex(ref)), _)                  => normalize(ref)
+        case (ReferenceF(parametersRegex(ref)), _)               => normalize(ref)
+        case (ReferenceF(ref), _)                                => normalize(ref)
       }
     }
     Printer(scheme.cata(algebra))
@@ -92,6 +92,7 @@ object print {
       case EnumF(_)      => false
       case ArrayF(_)     => false
       case ReferenceF(_) => false
+      case SumF(_)       => false
       case _             => true
     }
   }
@@ -153,7 +154,12 @@ object print {
   final case class VarWithType[T](name: Var, tpe: Tpe[T])
   object VarWithType {
     def tpe[T: Basis[JsonSchemaF, ?]](tpe: Tpe[T]): VarWithType[T] = VarWithType(Var(Tpe.name(tpe)), tpe)
-    def apply[T](name: String, tpe: T, required: Boolean, description: String, nestedTypes: List[String]): VarWithType[T] =
+    def apply[T](
+        name: String,
+        tpe: T,
+        required: Boolean,
+        description: String,
+        nestedTypes: List[String]): VarWithType[T] =
       VarWithType(Var(name), Tpe(tpe.asRight, required, description, nestedTypes))
   }
 

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -102,9 +102,9 @@ object print {
   }
 
   sealed trait Codecs
-  final case class CaseClassCodecs(name: String)                  extends Codecs
-  final case class ListCodecs(name: String)                       extends Codecs
-  final case class EnumCodecs(name: String, values: List[String]) extends Codecs
+  final case class CaseClassCodecs(name: String, fields: List[String]) extends Codecs
+  final case class ListCodecs(name: String)                            extends Codecs
+  final case class EnumCodecs(name: String, values: List[String])      extends Codecs
 
   final case class Tpe[T](tpe: Either[String, T], required: Boolean, description: String)
   object Tpe {
@@ -165,7 +165,7 @@ object print {
   def caseClassWithCodecsDef[T: Basis[JsonSchemaF, ?], A](
       implicit codecs: Printer[Codecs]): Printer[(String, List[(String, Tpe[T])])] =
     (caseClassDef[T], optional(newLine *< objectDef(codecs))).contramapN { x =>
-      ((x._1 -> x._2), (x._1, List.empty[PackageName], CaseClassCodecs(x._1)).some)
+      ((x._1 -> x._2), (x._1, List.empty[PackageName], CaseClassCodecs(x._1, x._2.map(_._1))).some)
     }
 
   def typeAliasDef[T](typeSchemaDef: Printer[T])(
@@ -205,7 +205,7 @@ object print {
     (κ("import ") *< show[PackageName]).contramap(identity)
 
   def argumentDef[T: Basis[JsonSchemaF, ?]]: Printer[Var[T]] =
-    divBy(string, κ(": "), tpe).contramap(x => x.name -> x.tpe)
+    divBy(string, κ(": "), tpe).contramap(x => decapitalize(normalize(x.name)) -> x.tpe)
 
   def un[A, B, C, D](pair: ((A, B), (C, D))): (A, B, C, D) = (pair._1._1, pair._1._2, pair._2._1, pair._2._2)
   def un[A, C, D](pair: (A, (C, D))): (A, C, D)            = (pair._1, pair._2._1, pair._2._2)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -45,18 +45,18 @@ object print {
     val algebra: Algebra[JsonSchemaF, String] = Algebra { x =>
       import JsonSchemaF._
       (x, name) match {
-        case (IntegerF(), _)                                     => "Int"
-        case (LongF(), _)                                        => "Long"
-        case (FloatF(), _)                                       => "Float"
-        case (DoubleF(), _)                                      => "Double"
-        case (StringF(), _)                                      => "String"
-        case (ByteF(), _)                                        => "Array[Byte]"
-        case (BinaryF(), _)                                      => "List[Boolean]"
-        case (BooleanF(), _)                                     => "Boolean"
-        case (DateF(), _)                                        => "java.time.LocalDate"
-        case (DateTimeF(), _)                                    => "java.time.ZonedDateTime"
-        case (PasswordF(), _)                                    => "String"
-        case (ObjectF(properties, _), _) if (properties.isEmpty) => "io.circe.Json"
+        case (IntegerF(), _)                                              => "Int"
+        case (LongF(), _)                                                 => "Long"
+        case (FloatF(), _)                                                => "Float"
+        case (DoubleF(), _)                                               => "Double"
+        case (StringF(), _)                                               => "String"
+        case (ByteF(), _)                                                 => "Array[Byte]"
+        case (BinaryF(), _)                                               => "List[Boolean]"
+        case (BooleanF(), _)                                              => "Boolean"
+        case (DateF(), _)                                                 => "java.time.LocalDate"
+        case (DateTimeF(), _)                                             => "java.time.ZonedDateTime"
+        case (PasswordF(), _)                                             => "String"
+        case (ObjectF(properties, _), Some(name)) if (properties.isEmpty) => s"type $name = io.circe.Json"
         case (ObjectF(properties, required), Some(name)) =>
           caseClassWithCodecsDef.print(
             (
@@ -71,7 +71,8 @@ object print {
                       name -> tpe.copy(required = false)
                 }))
 
-        case (ArrayF(x), _) => listDef.print(x)
+        case (ObjectF(properties, _), _) if (properties.isEmpty) => "io.circe.Json"
+        case (ArrayF(x), _)                                      => listDef.print(x)
         case (EnumF(fields), Some(name)) =>
           sealedTraitDef.print(name -> fields)
         case (ReferenceF(componentsRegex(ref)), _) => normalize(ref)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -190,7 +190,9 @@ object print {
       body >* newLine *< κ("}")
     ).contramap { case (x, y, z) => (x -> y, z) }
 
-  def normalize(value: String): String = value.split("[ _-]").map(_.filter(_.isLetterOrDigit).capitalize).mkString
+  def normalize(value: String): String =
+    value.dropWhile(_.isDigit).split("[ _-]").map(_.filter(_.isLetterOrDigit).capitalize).mkString ++ value.takeWhile(
+      _.isDigit)
 
   def divBy[A, B](p1: Printer[A], sep: Printer[Unit], p2: Printer[B]): Printer[(A, B)] =
     (p1, sep, p2).contramapN[(A, B)] { case (x, y) => (x, (), y) }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -30,6 +30,7 @@ object print {
   import higherkindness.skeuomorph.openapi.schema.OpenApi
 
   val componentsRegex = """#/components/schemas/(.+)""".r
+  val parametersRegex = """#/components/parameters/(.+)""".r
 
   def schemaWithName[T: Basis[JsonSchemaF, ?]](implicit codecs: Printer[Codecs]): Printer[(String, T)] = Printer {
     case (name, t) if (isBasicType(t)) => typeAliasDef(schema[T]()).print((normalize(name), t, none))

--- a/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
@@ -43,11 +43,16 @@ object schema {
 
     private def withSchemas[T](openApi: OpenApi[T])(models: Map[String, T]): OpenApi[T] = {
       openApi.copy(
-        components = openApi.components
-          .fold(
-            if (models.nonEmpty)
-              Components[T](schemas = models, responses = Map.empty, requestBodies = Map.empty).some
-            else none)(x => x.copy(x.schemas ++ models).some)
+        components =
+          openApi.components
+            .fold(
+              if (models.nonEmpty)
+                Components[T](
+                  schemas = models,
+                  responses = Map.empty,
+                  requestBodies = Map.empty,
+                  parameters = Map.empty).some
+              else none)(x => x.copy(x.schemas ++ models).some)
       )
     }
 
@@ -171,7 +176,8 @@ object schema {
   final case class Components[A](
       schemas: Map[String, A],
       responses: Map[String, Either[Response[A], Reference]],
-      requestBodies: Map[String, Either[Request[A], Reference]]
+      requestBodies: Map[String, Either[Request[A], Reference]],
+      parameters: Map[String, Either[Parameter[A], Reference]]
   )
 
   final case class Request[A](description: Option[String], content: Map[String, MediaType[A]], required: Boolean)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
@@ -159,6 +159,7 @@ object schema {
         patch: Option[Operation[A]],
         trace: Option[Operation[A]],
         servers: List[Server])
+    // TODO parameters: List[Either[Parameter[A], Reference]])
 
     final case class Operation[A](
         tags: List[String],

--- a/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
@@ -158,8 +158,8 @@ object schema {
         head: Option[Operation[A]],
         patch: Option[Operation[A]],
         trace: Option[Operation[A]],
-        servers: List[Server])
-    // TODO parameters: List[Either[Parameter[A], Reference]])
+        servers: List[Server],
+        parameters: List[Either[Parameter[A], Reference]])
 
     final case class Operation[A](
         tags: List[String],

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -220,6 +220,9 @@ object instances {
         Gen.option(booleanGen),
         Gen.option(booleanGen),
         T.arbitrary).mapN(Parameter.apply)
+
+    val parameters: Gen[List[Either[Parameter[T], Reference]]] = Gen.listOfN(2, eitherGen(parameterGen, referenceGen))
+
     val operationGen: Gen[Path.Operation[T]] =
       (
         Gen.listOfN(2, nonEmptyString),
@@ -227,7 +230,7 @@ object instances {
         Gen.option(nonEmptyString),
         Gen.option(externalDocsGen),
         Gen.option(nonEmptyString),
-        Gen.listOfN(2, eitherGen(parameterGen, referenceGen)),
+        parameters,
         Gen.option(eitherGen(requestGen, referenceGen)),
         responsesGen,
         Map.empty[String, Either[Callback[T], Reference]].pure[Gen],
@@ -247,7 +250,9 @@ object instances {
         Gen.option(operationGen),
         Gen.option(operationGen),
         Gen.option(operationGen),
-        serversGen).mapN(Path.ItemObject.apply)
+        serversGen,
+        parameters
+      ).mapN(Path.ItemObject.apply)
 
     val componentsGen: Gen[Components[T]] =
       (

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -250,7 +250,11 @@ object instances {
         serversGen).mapN(Path.ItemObject.apply)
 
     val componentsGen: Gen[Components[T]] =
-      (mapStringToGen(T.arbitrary), responsesGen, mapStringToGen(eitherGen(requestGen, referenceGen)))
+      (
+        mapStringToGen(T.arbitrary),
+        responsesGen,
+        mapStringToGen(eitherGen(requestGen, referenceGen)),
+        mapStringToGen(eitherGen(parameterGen, referenceGen)))
         .mapN(Components.apply)
 
     Arbitrary(

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -329,6 +329,7 @@ object instances {
         JsonSchemaF.password[T]().pure[Gen],
         T.arbitrary map JsonSchemaF.array,
         Gen.listOf(nonEmptyString) map JsonSchemaF.enum[T],
+        Gen.listOf(T.arbitrary) map JsonSchemaF.sum[T],
         objectGen,
         nonEmptyString.map(JsonSchemaF.reference[T])
       )

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaDecoderSpecification.scala
@@ -89,6 +89,16 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
         ))
       decoder.decodeJson(enumType) must beRight(Fixed.enum(List("green", "blue")))
     }
+    "when sum object is provided" >> {
+      val sumType = Json.obj(
+        "oneOf" -> Json.arr(
+          Json.obj(s"$$ref" -> Json.fromString("#/components/schemas/Cat")),
+          Json.obj(s"$$ref" -> Json.fromString("#/components/schemas/Dog"))
+        )
+      )
+      decoder.decodeJson(sumType) must beRight(
+        Fixed.sum(List(Fixed.reference("#/components/schemas/Cat"), Fixed.reference("#/components/schemas/Dog"))))
+    }
     "when array object is provided" >> {
       val arrayType = Json.obj(
         "type" -> Json.fromString("array"),

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -125,9 +125,13 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
     "when sum is provided" >> {
       schemaWithName
         .print(
-          "Animal" -> Fixed.sum(
+          "Pet" -> Fixed.sum(
             List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat")))) must
-        ===("""|type Animal = Dog :+: Cat :+: CNil""".stripMargin)
+        ===("""|type Pet = Dog :+: Cat :+: CNil
+               |object Pet {
+               |
+               |
+               |}""".stripMargin)
 
     }
   }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -121,6 +121,14 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
                |
                |}""".stripMargin)
     }
-  }
 
+    "when sum is provided" >> {
+      schemaWithName
+        .print(
+          "Animal" -> Fixed.sum(
+            List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat")))) must
+        ===("""|type Animal = Dog :+: Cat :+: CNil""".stripMargin)
+
+    }
+  }
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
@@ -131,12 +131,13 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
       }
       """)
 
-      val itemObject = emptyItemObject[JsonSchemaF.Fixed].withPost(
-        operation(
-          request("application/json" -> mediaType(Fixed.reference("#/components/schemas/SomePayload"))).optional
-            .withDescription("Callback payload"),
-          responses = "200" -> response("webhook successfully processed and no retries will be performed")
-        ))
+      val itemObject = emptyItemObject[JsonSchemaF.Fixed]
+        .withPost(
+          operation(
+            request("application/json" -> mediaType(Fixed.reference("#/components/schemas/SomePayload"))).optional
+              .withDescription("Callback payload"),
+            responses = "200" -> response("webhook successfully processed and no retries will be performed")
+          ))
 
       Decoder[Callback[JsonSchemaF.Fixed]].decodeJson(json) should beRight(
         Callback(
@@ -432,7 +433,9 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
         ]
       }""")
 
-      Decoder[Path.ItemObject[JsonSchemaF.Fixed]].decodeJson(json) must beRight(emptyItemObject[JsonSchemaF.Fixed])
+      Decoder[Path.ItemObject[JsonSchemaF.Fixed]].decodeJson(json) must beRight(
+        emptyItemObject[JsonSchemaF.Fixed].withParameter(
+          path("id", JsonSchemaF.Fixed.array(JsonSchemaF.Fixed.string()), description = "ID of pet to use".some)))
     }
 
     "when get operation is defined" >> {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
@@ -153,6 +153,50 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
         components[JsonSchemaF.Fixed]()
       )
     }
+    "when parameters are provided" >> {
+      val json = unsafeParse(""" 
+      {
+        "parameters": {
+          "skipParam": {
+            "name": "skip",
+            "in": "query",
+            "description": "number of items to skip",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          "limitParam": {
+            "name": "limit",
+            "in": "query",
+            "description": "max records to return",
+            "required": true,
+            "schema" : {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      }
+      """)
+      Decoder[Components[JsonSchemaF.Fixed]].decodeJson(json) must beRight(
+        components[JsonSchemaF.Fixed]().copy(parameters = Map(
+          "skipParam" -> query(
+            "skip",
+            JsonSchemaF.Fixed.integer(),
+            required = true,
+            description = "number of items to skip".some).asLeft,
+          "limitParam" -> query(
+            "limit",
+            JsonSchemaF.Fixed.integer(),
+            required = true,
+            description = "max records to return".some
+          ).asLeft
+        ))
+      )
+
+    }
     "when an schemas are provided" >> {
       val json = unsafeParse(""" 
       {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
@@ -26,13 +26,13 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
     "when nested objects are defined in schemas" >> {
       extractNestedTypes(
         openApi("name")
-          .withSchema("Foo" -> obj("bar" -> obj("x" -> Fixed.string())())())
-          .withSchema("Foos" -> Fixed.array(obj("y" -> Fixed.integer())()))) must ===(
+          .withSchema("Foo", obj("bar" -> obj("x" -> Fixed.string())())())
+          .withSchema("Foos", Fixed.array(obj("y" -> Fixed.integer())()))) must ===(
         openApi("name")
-          .withSchema("Bar" -> obj("x" -> Fixed.string)())
-          .withSchema("Foo" -> obj("bar" -> Fixed.reference("Bar"))())
-          .withSchema("AnonymousObject" -> obj("y" -> Fixed.integer())())
-          .withSchema("Foos" -> Fixed.array(Fixed.reference("AnonymousObject")))
+          .withSchema("Bar", obj("x" -> Fixed.string)())
+          .withSchema("Foo", obj("bar" -> Fixed.reference("Bar"))())
+          .withSchema("AnonymousObject", obj("y" -> Fixed.integer())())
+          .withSchema("Foos", Fixed.array(Fixed.reference("AnonymousObject")))
       )
     }
 
@@ -52,7 +52,7 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
                 request("application/json" -> mediaType(obj("foo" -> Fixed.reference("Foo"))())),
                 "200" -> response[JsonSchemaF.Fixed]("Null response")
               )))
-          .withSchema("Foo" -> Fixed.enum(List("1", "2"))))
+          .withSchema("Foo", Fixed.enum(List("1", "2"))))
     }
 
     "when nested objects are defined in request" >> {
@@ -73,7 +73,7 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
                   "Response",
                   "application/json" -> mediaType(obj("values" -> Fixed.array(Fixed.reference("AnonymousObject")))())))
               ))
-          .withSchema("AnonymousObject" -> obj("value" -> Fixed.integer())())
+          .withSchema("AnonymousObject", obj("value" -> Fixed.integer())())
       )
     }
   }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -58,14 +58,26 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}""".stripMargin)
     }
 
-    "when a object type is provided with not a normalize shape" >> {
-      import Printer.avoid._
-      model.print(petstoreOpenApi.withSchema("212bar_Foo-X1" -> obj("foo" -> Fixed.string())())) must ===(
+    "when a object type is provided with a not normalize shape" >> {
+      import client.http4s.circe._
+      model.print(petstoreOpenApi.withSchema(
+        "212bar_Foo-X1" -> obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())) must ===(
         """|object models {
            |
-           |final case class BarFooX1212(foo: Option[String])
+           |final case class BarFooX1212(foO1: Option[String], baR: Option[Int])
            |object BarFooX1212 {
            |
+           |  import io.circe._
+           |  import io.circe.generic.semiauto._
+           |  import org.http4s.{EntityEncoder, EntityDecoder}
+           |  import org.http4s.circe._
+           |  import cats.Applicative
+           |  import cats.effect.Sync
+           |  implicit val BarFooX1212Encoder: Encoder[BarFooX1212] = Encoder.forProduct2("1fo_o", "ba-r")(t => (t.foO1, t.baR))
+           |  implicit val BarFooX1212Decoder: Decoder[BarFooX1212] = Decoder.forProduct2("1fo_o", "ba-r")(BarFooX1212.apply)
+           |  implicit def BarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, BarFooX1212] = jsonEncoderOf[F, BarFooX1212]
+           |  implicit def OptionBarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[BarFooX1212]] = jsonEncoderOf[F, Option[BarFooX1212]]
+           |  implicit def BarFooX1212EntityDecoder[F[_]:Sync]: EntityDecoder[F, BarFooX1212] = jsonOf[F, BarFooX1212]
            |
            |}
            |}""".stripMargin)

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -27,7 +27,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
   "models should able to print" >> {
     "when a basic type is provided" >> {
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema("Foo" -> Fixed.string())) must
+      model.print(petstoreOpenApi.withSchema("Foo", Fixed.string())) must
         ===("""|object models {
                |
                |type Foo = String
@@ -36,7 +36,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when a object type is provided" >> {
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema("Bar" -> obj("foo" -> Fixed.string())())) must ===(
+      model.print(petstoreOpenApi.withSchema("Bar", obj("foo" -> Fixed.string())())) must ===(
         """|object models {
            |
            |final case class Bar(foo: Option[String])
@@ -60,8 +60,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when a object type is provided with a not normalize shape" >> {
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema(
-        "212bar_Foo-X1" -> obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())) must ===(
+      model.print(
+        petstoreOpenApi
+          .withSchema("212bar_Foo-X1", obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())) must ===(
         """|object models {
            |
            |final case class BarFooX1212(foO1: Option[String], baR: Option[Int])
@@ -87,7 +88,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       import client.http4s.circe._
       model.print(
         petstoreOpenApi.withSchema(
-          "Bars" -> Fixed.array(Fixed.reference("#/components/schemas/Bar"))
+          "Bars",
+          Fixed.array(Fixed.reference("#/components/schemas/Bar"))
         )) must ===("""|object models {
            |
            |type Bars = List[Bar]
@@ -98,7 +100,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       import Printer.avoid._
       model.print(
         petstoreOpenApi.withSchema(
-          "bar_Foo-X1s" -> Fixed.array(Fixed.reference("#/components/schemas/bar_Foo-X1"))
+          "bar_Foo-X1s",
+          Fixed.array(Fixed.reference("#/components/schemas/bar_Foo-X1"))
         )) must ===("""|object models {
              |
              |type BarFooX1s = List[BarFooX1]
@@ -107,7 +110,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when enum is provided" >> {
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema("Color" -> Fixed.enum(List("Blue", "Red")))) must ===(
+      model.print(petstoreOpenApi.withSchema("Color", Fixed.enum(List("Blue", "Red")))) must ===(
         """|object models {
            |
            |sealed trait Color
@@ -144,7 +147,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when enum is provided with a not normalize shape" >> {
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema("something-For" -> Fixed.enum(List("xo-m", "yy-y")))) must ===(
+      model.print(petstoreOpenApi.withSchema("something-For", Fixed.enum(List("xo-m", "yy-y")))) must ===(
         """|object models {
              |
              |sealed trait SomethingFor
@@ -183,9 +186,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       import Printer.avoid._
       model.print(
         petstoreOpenApi
-          .withSchema("Bar" -> obj("foo" -> Fixed.string())("foo"))
+          .withSchema("Bar", obj("foo" -> Fixed.string())("foo"))
           .withSchema(
-            "Bars" -> Fixed.array(Fixed.reference("#/components/schemas/Bar"))
+            "Bars",
+            Fixed.array(Fixed.reference("#/components/schemas/Bar"))
           )) must ===("""|object models {
                          |
                          |final case class Bar(foo: String)
@@ -822,7 +826,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       impl.print(
         PackageName("petstore") -> petstoreOpenApi
           .withPath(mediaTypeReferences)
-          .withSchema("NewPayloads" -> Fixed.array(Fixed.reference("NewPayload")))) must ===(
+          .withSchema("NewPayloads", Fixed.array(Fixed.reference("NewPayload")))) must ===(
         s"""|import cats.effect._
            |import cats.implicits._
            |import io.circe._

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -584,8 +584,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
                     |trait PetstoreClient[F[_]] {
                     |  import PetstoreClient._
                     |  def createPets(newPet: NewPet): F[Unit]
-                    |  def updatePets(id: String, updatePet: UpdatePet): F[Unit]
-                    |  def getOwnersPets(id: String): F[Owners]
+                    |  def updatePetsById(id: String, updatePet: UpdatePet): F[Unit]
+                    |  def getOwnersPetsById(id: String): F[Owners]
                     |}
                     |object PetstoreClient {
                     |
@@ -829,7 +829,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$listCodecsImplicits
-           |    def get1id(id1: String, limitFor: Option[Int], listString: List[String]): F[Unit] = client.expect[Unit](Request[F](method = Method.GET, uri = baseUrl / "1id" / id1.show +?? ("limit-for", limitFor)).with(listString))
+           |    def getId1ById1(id1: String, limitFor: Option[Int], listString: List[String]): F[Unit] = client.expect[Unit](Request[F](method = Method.GET, uri = baseUrl / "1id" / id1.show +?? ("limit-for", limitFor)).with(listString))
            |  }
            |
            |}""".stripMargin

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -1085,7 +1085,7 @@ object OpenApiPrintSpecification {
     .withGet(
       operation[JsonSchemaF.Fixed](request("application/json" -> mediaType(Fixed.array(Fixed.string()))), successNull)
         .withParameter(path("1id", Fixed.string()))
-        .withParameter(query("limit-for", Fixed.integer())),
+        .withParameter(query("limit-for", Fixed.integer()))
     )
 
   val listImplicits =

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -386,7 +386,25 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     "when there are simple response and response with anonymous objects" >> {
       import client.http4s.circe._
-      interfaceDefinition.print(anotherPayloadOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
+      interfaceDefinition.print(anotherPayloadOpenApi.withPath(objectRequestResponseAnonymousObjects)) must ===(
+        """|import models._
+           |import shapeless.{:+:, CNil}
+           |trait AnotherPayloadClient[F[_]] {
+           |  import AnotherPayloadClient._
+           |  def updateAnotherPayload(id: String, updateAnotherPayloadRequest: UpdateAnotherPayloadRequest): F[UpdatedPayload]
+           |}
+           |object AnotherPayloadClient {
+           |
+           |  type UpdateAnotherPayloadRequest = io.circe.Json
+           |  type UpdatedPayload = io.circe.Json
+           |
+           |}""".stripMargin
+      )
+    }
+
+    "when there are simple response and response with anonymous objects" >> {
+      import client.http4s.circe._
+      interfaceDefinition.print(anotherPayloadOpenApi.withPath(simpleRequestResponseAnonymousObjects)) must ===(
         """|import models._
            |import shapeless.{:+:, CNil}
            |trait AnotherPayloadClient[F[_]] {
@@ -723,7 +741,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     }
 
     "when there are simple response and response with anonymous objects" >> {
-      implDefinition.print(petstoreOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
+      implDefinition.print(petstoreOpenApi.withPath(simpleRequestResponseAnonymousObjects)) must ===(
         s"""|object PetstoreHttpClient {
           |
           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
@@ -1051,7 +1069,20 @@ object OpenApiPrintSpecification {
       ).withOperationId("updatePayload").withParameter(path("id", Fixed.string()))
     )
 
-  val simpleResponseResponseAnonymousObjects = "/payloads/{id}" -> emptyItemObject
+  val objectRequestResponseAnonymousObjects = "/payloads/{id}" -> emptyItemObject
+    .withPut(
+      operation[JsonSchemaF.Fixed](
+        request(
+          "*/*" -> mediaType(obj()())
+        ),
+        responses = "200" -> response(
+          "Updated payload",
+          "application/json" -> mediaType(obj()())
+        )
+      ).withOperationId("updateAnotherPayload").withParameter(path("id", Fixed.string()))
+    )
+
+  val simpleRequestResponseAnonymousObjects = "/payloads/{id}" -> emptyItemObject
     .withPut(
       operation[JsonSchemaF.Fixed](
         request(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -996,6 +996,7 @@ object OpenApiPrintSpecification {
           "",
           "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
       ).withOperationId("getPayload")
+        .withParameter(path("id", JsonSchemaF.Fixed.string()))
         .withParameter(Reference("#/components/parameters/initParam"))
         .withParameter(Reference("#/components/parameters/limitParam"))
     )

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -648,7 +648,6 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(
         petstoreOpenApi
           .withPath(parametersReferenceGet)
-          .withParameter("idParam", path("id", JsonSchemaF.Fixed.string()))
           .withParameter("initParam", query("init", JsonSchemaF.Fixed.long(), required = true))
           .withParameter("limitParam", query("limit", JsonSchemaF.Fixed.integer()))
       ) must ===(
@@ -989,16 +988,17 @@ object OpenApiPrintSpecification {
       .withParameter(query("name", Fixed.string()))
   )
 
-  val parametersReferenceGet = payloadPathId -> emptyItemObject.withGet(
-    operationWithResponses[JsonSchemaF.Fixed](
-      responses = "200" -> response(
-        "",
-        "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
-    ).withOperationId("getPayload")
-      .withParameter(Reference("#/components/parameters/idParam"))
-      .withParameter(Reference("#/components/parameters/initParam"))
-      .withParameter(Reference("#/components/parameters/limitParam"))
-  )
+  val parametersReferenceGet = payloadPathId -> emptyItemObject
+    .withParameter(path("id", JsonSchemaF.Fixed.string()))
+    .withGet(
+      operationWithResponses[JsonSchemaF.Fixed](
+        responses = "200" -> response(
+          "",
+          "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
+      ).withOperationId("getPayload")
+        .withParameter(Reference("#/components/parameters/initParam"))
+        .withParameter(Reference("#/components/parameters/limitParam"))
+    )
   val mediaTypeReferenceGetId = payloadPathId -> emptyItemObject
     .withGet(
       operationWithResponses[JsonSchemaF.Fixed](successPayload)

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -604,8 +604,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     implicit val none: Http4sSpecifics = new Http4sSpecifics {
       def none[A]                                     = Printer.unit.contramap[A](_ => ())
       def applyMethod: Printer[(TraitName, ImplName)] = none
-      def withBody: Printer[String] = Printer { x =>
-        s".with(${decapitalize(normalize(x))})"
+      def withBody: Printer[Var] = Printer { x =>
+        s".with(${x.show})"
       }
 
     }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -1018,7 +1018,7 @@ object OpenApiPrintSpecification {
     .withPut(
       operation[JsonSchemaF.Fixed](
         request(
-          "application/json" -> mediaType(obj("name" -> Fixed.string())("name"))
+          "*/*" -> mediaType(obj("name" -> Fixed.string())("name"))
         ),
         responses = "200" -> response(
           "Updated payload",
@@ -1061,7 +1061,7 @@ object OpenApiPrintSpecification {
         responses = successNull,
         "default" -> response(
           "Unexpected error",
-          "application/json" -> mediaType(obj("isDone" -> Fixed.boolean())("isDone"))
+          "*/*" -> mediaType(obj("isDone" -> Fixed.boolean())("isDone"))
         )
       )
     )

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -294,11 +294,13 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def getPayload(status: Status): F[Unit]
+           |  def getPayload(status: parameters.Status): F[Unit]
            |}
            |object PayloadClient {
            |
            |
+           |
+           |object parameters {
            |
            |sealed trait Status
            |object Status {
@@ -327,6 +329,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  implicit def OptionStatusEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Status]] = jsonEncoderOf[F, Option[Status]]
            |  implicit def StatusEntityDecoder[F[_]:Sync]: EntityDecoder[F, Status] = jsonOf[F, Status]
            |
+           |}
            |}
            |
            |}""".stripMargin
@@ -741,7 +744,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
           |    import PetstoreClient._
           |$defaultImplicits
-          |    def getPayload(id: String, init: Long, limit: Option[Int]): F[Payloads] = client.expect[Payloads](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show +? ("init", init) +?? ("limit", limit)))
+          |    def getPayload(id: String, init: Long, limit: Option[Int], color: Color): F[Payloads] = client.expect[Payloads](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show +? ("init", init) +?? ("limit", limit)))
           |  }
           |
           |}""".stripMargin
@@ -1088,6 +1091,7 @@ object OpenApiPrintSpecification {
         .withParameter(path("id", JsonSchemaF.Fixed.string()))
         .withParameter(Reference("#/components/parameters/initParam"))
         .withParameter(Reference("#/components/parameters/limitParam"))
+        .withParameter(path("color", JsonSchemaF.Fixed.reference("#/components/schemas/Color")))
     )
 
   val enumParameterGet = payloadPathId -> emptyItemObject

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -299,13 +299,13 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def getPayload(id: String): F[Either[GetPayloadError, Payload]]
+           |  def getPayload(id: String): F[Either[GetPayloadErrorResponse, Payload]]
            |}
            |object PayloadClient {
            |
            |
            |  final case class GetPayloadUnexpectedErrorResponse(statusCode: Int, value: Error)
-           |  type GetPayloadError = GetPayloadUnexpectedErrorResponse
+           |  type GetPayloadErrorResponse = GetPayloadUnexpectedErrorResponse
            |
            |}""".stripMargin)
     }
@@ -317,13 +317,13 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def getPayload(id: String): F[Either[GetPayloadError, Payload]]
+           |  def getPayload(id: String): F[Either[GetPayloadErrorResponse, Payload]]
            |}
            |object PayloadClient {
            |
            |
            |  final case class GetPayloadNotFoundError(value: String)
-           |  type GetPayloadError = GetPayloadNotFoundError
+           |  type GetPayloadErrorResponse = GetPayloadNotFoundError
            |
            |}""".stripMargin
       )
@@ -336,7 +336,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]]
+           |  def updatePayload(id: String): F[Either[UpdatePayloadErrorResponse, UpdatedPayload]]
            |}
            |object PayloadClient {
            |
@@ -373,7 +373,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  implicit def UpdatePayloadNotFoundEntityDecoder[F[_]:Sync]: EntityDecoder[F, UpdatePayloadNotFound] = jsonOf[F, UpdatePayloadNotFound]
            |
            |}
-           |  type UpdatePayloadError = UpdatePayloadNotFound
+           |  type UpdatePayloadErrorResponse = UpdatePayloadNotFound
            |
            |}""".stripMargin
       )
@@ -435,7 +435,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]]
+           |  def updatePayload(id: String): F[Either[UpdatePayloadErrorResponse, UpdatedPayload]]
            |}
            |object PayloadClient {
            |
@@ -451,7 +451,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |}
            |  final case class UpdatePayloadUnexpectedErrorResponse(statusCode: Int, value: UpdatePayloadUnexpectedError)
-           |  type UpdatePayloadError = UpdatePayloadUnexpectedErrorResponse
+           |  type UpdatePayloadErrorResponse = UpdatePayloadUnexpectedErrorResponse
            |
            |}""".stripMargin
       )
@@ -464,14 +464,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def createPayload(): F[Either[CreatePayloadError, Unit]]
+           |  def createPayload(): F[Either[CreatePayloadErrorResponse, Unit]]
            |}
            |object PayloadClient {
            |
            |
            |  final case class CreatePayloadNotFoundError(value: String)
            |  final case class CreatePayloadUnexpectedErrorResponse(statusCode: Int, value: Error)
-           |  type CreatePayloadError = CreatePayloadNotFoundError :+: CreatePayloadUnexpectedErrorResponse :+: CNil
+           |  type CreatePayloadErrorResponse = CreatePayloadNotFoundError :+: CreatePayloadUnexpectedErrorResponse :+: CNil
            |
            |}""".stripMargin
       )
@@ -484,8 +484,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def createPayloads(): F[Either[CreatePayloadsError, Unit]]
-           |  def updatePayloads(): F[Either[UpdatePayloadsError, Unit]]
+           |  def createPayloads(): F[Either[CreatePayloadsErrorResponse, Unit]]
+           |  def updatePayloads(): F[Either[UpdatePayloadsErrorResponse, Unit]]
            |}
            |object PayloadClient {
            |
@@ -497,14 +497,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |}
            |  final case class CreatePayloadsUnexpectedErrorResponse(statusCode: Int, value: CreatePayloadsUnexpectedError)
-           |  type CreatePayloadsError = CreatePayloadsUnexpectedErrorResponse
+           |  type CreatePayloadsErrorResponse = CreatePayloadsUnexpectedErrorResponse
            |  final case class UpdatePayloadsUnexpectedError(isDone: Boolean)
            |object UpdatePayloadsUnexpectedError {
            |
            |
            |}
            |  final case class UpdatePayloadsUnexpectedErrorResponse(statusCode: Int, value: UpdatePayloadsUnexpectedError)
-           |  type UpdatePayloadsError = UpdatePayloadsUnexpectedErrorResponse
+           |  type UpdatePayloadsErrorResponse = UpdatePayloadsUnexpectedErrorResponse
            |
            |}""".stripMargin
       )
@@ -517,13 +517,13 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def deletePayloads(): F[Either[DeletePayloadsError, Unit]]
+           |  def deletePayloads(): F[Either[DeletePayloadsErrorResponse, Unit]]
            |}
            |object PayloadClient {
            |
            |
            |  final case class DeletePayloadsNotFoundError(value: Unit)
-           |  type DeletePayloadsError = DeletePayloadsNotFoundError
+           |  type DeletePayloadsErrorResponse = DeletePayloadsNotFoundError
            |
            |}""".stripMargin)
     }
@@ -535,14 +535,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def deletePayloads(): F[Either[DeletePayloadsError, Unit]]
+           |  def deletePayloads(): F[Either[DeletePayloadsErrorResponse, Unit]]
            |}
            |object PayloadClient {
            |
            |
            |  final case class DeletePayloadsNotFoundError(value: Unit)
            |  final case class DeletePayloadsUnexpectedErrorResponse(statusCode: Int, value: Unit)
-           |  type DeletePayloadsError = DeletePayloadsNotFoundError :+: DeletePayloadsUnexpectedErrorResponse :+: CNil
+           |  type DeletePayloadsErrorResponse = DeletePayloadsNotFoundError :+: DeletePayloadsUnexpectedErrorResponse :+: CNil
            |
            |}""".stripMargin)
     }
@@ -674,7 +674,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |$listCodecsImplicits
-           |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
+           |    def getPayload(id: String): F[Either[GetPayloadErrorResponse, Payload]] = client.fetch[Either[GetPayloadErrorResponse, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[Payload].map(_.asRight)
            |      case default => default.as[Error].map(x => GetPayloadUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
@@ -689,7 +689,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |$listCodecsImplicits
-           |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
+           |    def getPayload(id: String): F[Either[GetPayloadErrorResponse, Payload]] = client.fetch[Either[GetPayloadErrorResponse, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[Payload].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[String].map(x => GetPayloadNotFoundError(x).asLeft)
            |    }
@@ -718,7 +718,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$listCodecsImplicits
-           |    def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]] = client.fetch[Either[UpdatePayloadError, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
+           |    def updatePayload(id: String): F[Either[UpdatePayloadErrorResponse, UpdatedPayload]] = client.fetch[Either[UpdatePayloadErrorResponse, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[UpdatedPayload].map(_.asRight)
            |      case default => default.as[UpdatePayloadUnexpectedError].map(x => UpdatePayloadUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
@@ -734,10 +734,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$listCodecsImplicits
-           |    def createPayload(): F[Either[CreatePayloadError, Unit]] = client.fetch[Either[CreatePayloadError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads")) {
+           |    def createPayload(): F[Either[CreatePayloadErrorResponse, Unit]] = client.fetch[Either[CreatePayloadErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
-           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[CreatePayloadError](CreatePayloadNotFoundError(x)).asLeft)
-           |      case default => default.as[Error].map(x => Coproduct[CreatePayloadError](CreatePayloadUnexpectedErrorResponse(default.status.code, x)).asLeft)
+           |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[CreatePayloadErrorResponse](CreatePayloadNotFoundError(x)).asLeft)
+           |      case default => default.as[Error].map(x => Coproduct[CreatePayloadErrorResponse](CreatePayloadUnexpectedErrorResponse(default.status.code, x)).asLeft)
            |    }
            |  }
            |
@@ -752,7 +752,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$listCodecsImplicits
-           |    def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]] = client.fetch[Either[UpdatePayloadError, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
+           |    def updatePayload(id: String): F[Either[UpdatePayloadErrorResponse, UpdatedPayload]] = client.fetch[Either[UpdatePayloadErrorResponse, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[UpdatedPayload].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[UpdatePayloadNotFound].map(x => x.asLeft)
            |    }
@@ -769,7 +769,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$listCodecsImplicits
-           |    def deletePayloads(): F[Either[DeletePayloadsError, Unit]] = client.fetch[Either[DeletePayloadsError, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
+           |    def deletePayloads(): F[Either[DeletePayloadsErrorResponse, Unit]] = client.fetch[Either[DeletePayloadsErrorResponse, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[Unit].map(x => DeletePayloadsNotFoundError(x).asLeft)
            |    }
@@ -786,10 +786,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$listCodecsImplicits
-           |    def deletePayloads(): F[Either[DeletePayloadsError, Unit]] = client.fetch[Either[DeletePayloadsError, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
+           |    def deletePayloads(): F[Either[DeletePayloadsErrorResponse, Unit]] = client.fetch[Either[DeletePayloadsErrorResponse, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
-           |      case response if response.status.code == 404 => response.as[Unit].map(x => Coproduct[DeletePayloadsError](DeletePayloadsNotFoundError(x)).asLeft)
-           |      case default => default.as[Unit].map(x => Coproduct[DeletePayloadsError](DeletePayloadsUnexpectedErrorResponse(default.status.code, x)).asLeft)
+           |      case response if response.status.code == 404 => response.as[Unit].map(x => Coproduct[DeletePayloadsErrorResponse](DeletePayloadsNotFoundError(x)).asLeft)
+           |      case default => default.as[Unit].map(x => Coproduct[DeletePayloadsErrorResponse](DeletePayloadsUnexpectedErrorResponse(default.status.code, x)).asLeft)
            |    }
            |  }
            |
@@ -840,7 +840,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |$listCodecsImplicits
-           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads)) {
+           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads)) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
@@ -876,7 +876,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
            |$listCodecsImplicits
-           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads)) {
+           |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads)) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -29,34 +29,33 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when a basic type is provided" >> {
       import client.http4s.circe._
       model.print(petstoreOpenApi.withSchema("Foo", Fixed.string())) must
-        ===("""|object models {
-               |
-               |type Foo = String
-               |}""".stripMargin)
+        ===(s"""|object models {
+                |$modelImports
+                |type Foo = String
+                |}""".stripMargin)
     }
 
     "when a object type is provided" >> {
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema("Bar", obj("foo" -> Fixed.string())())) must ===(
-        """|object models {
-           |
-           |final case class Bar(foo: Option[String])
-           |object Bar {
-           |
-           |  import io.circe._
-           |  import io.circe.generic.semiauto._
-           |  import org.http4s.{EntityEncoder, EntityDecoder}
-           |  import org.http4s.circe._
-           |  import cats.Applicative
-           |  import cats.effect.Sync
-           |  implicit val BarEncoder: Encoder[Bar] = deriveEncoder[Bar]
-           |  implicit val BarDecoder: Decoder[Bar] = deriveDecoder[Bar]
-           |  implicit def BarEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Bar] = jsonEncoderOf[F, Bar]
-           |  implicit def OptionBarEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Bar]] = jsonEncoderOf[F, Option[Bar]]
-           |  implicit def BarEntityDecoder[F[_]:Sync]: EntityDecoder[F, Bar] = jsonOf[F, Bar]
-           |
-           |}
-           |}""".stripMargin)
+      model.print(petstoreOpenApi.withSchema("Bar", obj("foo" -> Fixed.string())())) must ===(s"""|object models {
+            |$modelImports
+            |final case class Bar(foo: Option[String])
+            |object Bar {
+            |
+            |  import io.circe._
+            |  import io.circe.generic.semiauto._
+            |  import org.http4s.{EntityEncoder, EntityDecoder}
+            |  import org.http4s.circe._
+            |  import cats.Applicative
+            |  import cats.effect.Sync
+            |  implicit val BarEncoder: Encoder[Bar] = deriveEncoder[Bar]
+            |  implicit val BarDecoder: Decoder[Bar] = deriveDecoder[Bar]
+            |  implicit def BarEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Bar] = jsonEncoderOf[F, Bar]
+            |  implicit def OptionBarEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Bar]] = jsonEncoderOf[F, Option[Bar]]
+            |  implicit def BarEntityDecoder[F[_]:Sync]: EntityDecoder[F, Bar] = jsonOf[F, Bar]
+            |
+            |}
+            |}""".stripMargin)
     }
 
     "when a object type is provided with a not normalize shape" >> {
@@ -64,25 +63,25 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       model.print(
         petstoreOpenApi
           .withSchema("212bar_Foo-X1", obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())) must ===(
-        """|object models {
-           |
-           |final case class BarFooX1212(foO1: Option[String], baR: Option[Int])
-           |object BarFooX1212 {
-           |
-           |  import io.circe._
-           |  import io.circe.generic.semiauto._
-           |  import org.http4s.{EntityEncoder, EntityDecoder}
-           |  import org.http4s.circe._
-           |  import cats.Applicative
-           |  import cats.effect.Sync
-           |  implicit val BarFooX1212Encoder: Encoder[BarFooX1212] = Encoder.forProduct2("1fo_o", "ba-r")(t => (t.foO1, t.baR))
-           |  implicit val BarFooX1212Decoder: Decoder[BarFooX1212] = Decoder.forProduct2("1fo_o", "ba-r")(BarFooX1212.apply)
-           |  implicit def BarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, BarFooX1212] = jsonEncoderOf[F, BarFooX1212]
-           |  implicit def OptionBarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[BarFooX1212]] = jsonEncoderOf[F, Option[BarFooX1212]]
-           |  implicit def BarFooX1212EntityDecoder[F[_]:Sync]: EntityDecoder[F, BarFooX1212] = jsonOf[F, BarFooX1212]
-           |
-           |}
-           |}""".stripMargin)
+        s"""|object models {
+            |$modelImports
+            |final case class BarFooX1212(foO1: Option[String], baR: Option[Int])
+            |object BarFooX1212 {
+            |
+            |  import io.circe._
+            |  import io.circe.generic.semiauto._
+            |  import org.http4s.{EntityEncoder, EntityDecoder}
+            |  import org.http4s.circe._
+            |  import cats.Applicative
+            |  import cats.effect.Sync
+            |  implicit val BarFooX1212Encoder: Encoder[BarFooX1212] = Encoder.forProduct2("1fo_o", "ba-r")(t => (t.foO1, t.baR))
+            |  implicit val BarFooX1212Decoder: Decoder[BarFooX1212] = Decoder.forProduct2("1fo_o", "ba-r")(BarFooX1212.apply)
+            |  implicit def BarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, BarFooX1212] = jsonEncoderOf[F, BarFooX1212]
+            |  implicit def OptionBarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[BarFooX1212]] = jsonEncoderOf[F, Option[BarFooX1212]]
+            |  implicit def BarFooX1212EntityDecoder[F[_]:Sync]: EntityDecoder[F, BarFooX1212] = jsonOf[F, BarFooX1212]
+            |
+            |}
+            |}""".stripMargin)
     }
 
     "when an array is provided" >> {
@@ -91,10 +90,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
         petstoreOpenApi.withSchema(
           "Bars",
           Fixed.array(Fixed.reference("#/components/schemas/Bar"))
-        )) must ===("""|object models {
-           |
-           |type Bars = List[Bar]
-           |}""".stripMargin)
+        )) must ===(s"""|object models {
+              |$modelImports
+              |type Bars = List[Bar]
+              |}""".stripMargin)
     }
 
     "when a array type is provided with a not normalize shape" >> {
@@ -103,54 +102,54 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
         petstoreOpenApi.withSchema(
           "bar_Foo-X1s",
           Fixed.array(Fixed.reference("#/components/schemas/bar_Foo-X1"))
-        )) must ===("""|object models {
-             |
-             |type BarFooX1s = List[BarFooX1]
-             |}""".stripMargin)
+        )) must ===(s"""|object models {
+              |$modelImports
+              |type BarFooX1s = List[BarFooX1]
+              |}""".stripMargin)
     }
 
     "when enum is provided" >> {
       import client.http4s.circe._
       model.print(petstoreOpenApi.withSchema("Color", Fixed.enum(List("Blue", "Red")))) must ===(
-        """|object models {
-           |
-           |sealed trait Color
-           |object Color {
-           |
-           |  final case object Blue extends Color
-           |  final case object Red extends Color
-           |  import org.http4s.{EntityEncoder, EntityDecoder}
-           |  import org.http4s.circe._
-           |  import cats.Applicative
-           |  import cats.effect.Sync
-           |  import cats._
-           |  import cats.implicits._
-           |  import io.circe._
-           |  implicit val ColorShow: Show[Color] = Show.show {
-           |  case Blue => "Blue"
-           |  case Red => "Red"
-           |}
-           |  implicit val ColorEncoder: Encoder[Color] = Encoder.encodeString.contramap(_.show)
-           |  implicit val ColorDecoder: Decoder[Color] = Decoder.decodeString.emap {
-           |  case "Blue" => Blue.asRight
-           |  case "Red" => Red.asRight
-           |  case x => s"$x is not valid Color".asLeft
-           |}
-           |
-           |  implicit def ColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Color] = jsonEncoderOf[F, Color]
-           |  implicit def OptionColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Color]] = jsonEncoderOf[F, Option[Color]]
-           |  implicit def ColorEntityDecoder[F[_]:Sync]: EntityDecoder[F, Color] = jsonOf[F, Color]
-           |
-           |}
-           |}""".stripMargin
+        s"""|object models {
+            |$modelImports
+            |sealed trait Color
+            |object Color {
+            |
+            |  final case object Blue extends Color
+            |  final case object Red extends Color
+            |  import org.http4s.{EntityEncoder, EntityDecoder}
+            |  import org.http4s.circe._
+            |  import cats.Applicative
+            |  import cats.effect.Sync
+            |  import cats._
+            |  import cats.implicits._
+            |  import io.circe._
+            |  implicit val ColorShow: Show[Color] = Show.show {
+            |  case Blue => "Blue"
+            |  case Red => "Red"
+            |}
+            |  implicit val ColorEncoder: Encoder[Color] = Encoder.encodeString.contramap(_.show)
+            |  implicit val ColorDecoder: Decoder[Color] = Decoder.decodeString.emap {
+            |  case "Blue" => Blue.asRight
+            |  case "Red" => Red.asRight
+            |  case x => s"$$x is not valid Color".asLeft
+            |}
+            |
+            |  implicit def ColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Color] = jsonEncoderOf[F, Color]
+            |  implicit def OptionColorEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Color]] = jsonEncoderOf[F, Option[Color]]
+            |  implicit def ColorEntityDecoder[F[_]:Sync]: EntityDecoder[F, Color] = jsonOf[F, Color]
+            |
+            |}
+            |}""".stripMargin
       )
     }
 
     "when enum is provided with a not normalize shape" >> {
       import client.http4s.circe._
       model.print(petstoreOpenApi.withSchema("something-For", Fixed.enum(List("xo-m", "yy-y")))) must ===(
-        """|object models {
-             |
+        s"""|object models {
+             |$modelImports
              |sealed trait SomethingFor
              |object SomethingFor {
              |
@@ -171,7 +170,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
              |  implicit val SomethingForDecoder: Decoder[SomethingFor] = Decoder.decodeString.emap {
              |  case "xo-m" => XoM.asRight
              |  case "yy-y" => YyY.asRight
-             |  case x => s"$x is not valid SomethingFor".asLeft
+             |  case x => s"$$x is not valid SomethingFor".asLeft
              |}
              |
              |  implicit def SomethingForEntityEncoder[F[_]:Applicative]: EntityEncoder[F, SomethingFor] = jsonEncoderOf[F, SomethingFor]
@@ -183,6 +182,44 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       )
     }
 
+    "when a sum type is provided" >> {
+
+      import client.http4s.circe._
+      model.print(petstoreOpenApi.withSchema(
+        "Pet",
+        Fixed.sum(List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat"))))) must ===(
+        s"""|object models {
+            |$modelImports
+            |import Pet._
+            |type Pet = Dog :+: Cat :+: CNil
+            |object Pet {
+            |
+            |  import org.http4s.{EntityEncoder, EntityDecoder}
+            |  import org.http4s.circe._
+            |  import cats.Applicative
+            |  import cats.effect.Sync
+            |  import cats._
+            |  import cats.implicits._
+            |  import io.circe._
+            |  implicit val PetEncoder: Encoder[Pet] = Encoder.instance { x =>
+            |import shapeless.Poly1
+            |object json extends Poly1 {
+            |
+            |implicit def dog = at[Dog](x => Encoder[Dog].apply(x))
+            |implicit def cat = at[Cat](x => Encoder[Cat].apply(x))
+            |}
+            |x.fold(json)
+            |}
+            |  implicit val PetDecoder: Decoder[Pet] = Decoder[Dog].map(x => Coproduct[Pet](x)) orElse Decoder[Cat].map(x => Coproduct[Pet](x))
+            |  implicit def PetEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Pet] = jsonEncoderOf[F, Pet]
+            |  implicit def OptionPetEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Pet]] = jsonEncoderOf[F, Option[Pet]]
+            |  implicit def PetEntityDecoder[F[_]:Sync]: EntityDecoder[F, Pet] = jsonOf[F, Pet]
+            |
+            |}
+            |}""".stripMargin)
+
+    }
+
     "when multiple types are provided" >> {
       import Printer.avoid._
       model.print(
@@ -191,15 +228,15 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           .withSchema(
             "Bars",
             Fixed.array(Fixed.reference("#/components/schemas/Bar"))
-          )) must ===("""|object models {
-                         |
-                         |final case class Bar(foo: String)
-                         |object Bar {
-                         |
-                         |
-                         |}
-                         |type Bars = List[Bar]
-                         |}""".stripMargin)
+          )) must ===(s"""|object models {
+                          |$modelImports
+                          |final case class Bar(foo: String)
+                          |object Bar {
+                          |
+                          |
+                          |}
+                          |type Bars = List[Bar]
+                          |}""".stripMargin)
     }
   }
 
@@ -934,33 +971,36 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       impl.print(
         PackageName("petstore") -> petstoreOpenApi
           .withPath(mediaTypeReferences)
-          .withSchema("NewPayloads", Fixed.array(Fixed.reference("NewPayload")))) must ===(
+          .withSchema("NewPayloads", Fixed.array(Fixed.reference("NewPayload")))
+          .withSchema("FooBar", Fixed.sum(List(Fixed.reference("Foo"), Fixed.reference("Bar"))))
+      ) must ===(
         s"""|import cats._
             |import cats.effect._
-           |import cats.implicits._
-           |import io.circe._
-           |import org.http4s._
-           |import org.http4s.client.Client
-           |import org.http4s.client.blaze._
-           |import org.http4s.circe._
-           |import org.http4s.Status.Successful
-           |import shapeless.Coproduct
-           |import scala.concurrent.ExecutionContext
-           |import petstore.PetstoreClient
-           |import petstore.models._
-           |object PetstoreHttpClient {
-           |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
-           |    import PetstoreClient._
-           |$defaultImplicits
-           |    def createPayloads(xAuth: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads).withHeaders(Headers.of(Header("X-Auth", xAuth.show), Header("token", token.show)))) {
-           |      case Successful(response) => response.as[Unit].map(_.asRight)
-           |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
-           |    }
-           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withEntity(payloads))
-           |  }
-           |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext, $timeQueryParamEncoders): Resource[F, PetstoreClient[F]] = BlazeClientBuilder(executionContext).resource.map(PetstoreHttpClient.build(_, baseUrl))
-           |}""".stripMargin
+            |import cats.implicits._
+            |import io.circe._
+            |import org.http4s._
+            |import org.http4s.client.Client
+            |import org.http4s.client.blaze._
+            |import org.http4s.circe._
+            |import org.http4s.Status.Successful
+            |import shapeless.Coproduct
+            |import scala.concurrent.ExecutionContext
+            |import petstore.PetstoreClient
+            |import petstore.models._
+            |import FooBar._
+            |object PetstoreHttpClient {
+            |
+            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
+            |    import PetstoreClient._
+            |$defaultImplicits
+            |    def createPayloads(xAuth: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads).withHeaders(Headers.of(Header("X-Auth", xAuth.show), Header("token", token.show)))) {
+            |      case Successful(response) => response.as[Unit].map(_.asRight)
+            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
+            |    }
+            |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withEntity(payloads))
+            |  }
+            |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext, $timeQueryParamEncoders): Resource[F, PetstoreClient[F]] = BlazeClientBuilder(executionContext).resource.map(PetstoreHttpClient.build(_, baseUrl))
+            |}""".stripMargin
       )
     }
   }
@@ -974,30 +1014,30 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       impl.print(PackageName("petstore") -> petstoreOpenApi.withPath(mediaTypeReferences)) must ===(
         s"""|import cats._
         |import cats.effect._
-           |import cats.implicits._
-           |import io.circe._
-           |import org.http4s._
-           |import org.http4s.client.Client
-           |import org.http4s.client.blaze._
-           |import org.http4s.circe._
-           |import org.http4s.Status.Successful
-           |import shapeless.Coproduct
-           |import scala.concurrent.ExecutionContext
-           |import petstore.PetstoreClient
-           |import petstore.models._
-           |object PetstoreHttpClient {
-           |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
-           |    import PetstoreClient._
-           |$defaultImplicits
-           |    def createPayloads(xAuth: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads).withHeaders(Headers(Header("X-Auth", xAuth.show), Header("token", token.show)))) {
-           |      case Successful(response) => response.as[Unit].map(_.asRight)
-           |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
-           |    }
-           |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withBody(payloads))
-           |  }
-           |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext, $timeQueryParamEncoders): F[PetstoreClient[F]] = Http1Client[F](config = BlazeClientConfig.defaultConfig.copy(executionContext = executionContext)).map(PetstoreHttpClient.build(_, baseUrl))
-           |}""".stripMargin
+        |import cats.implicits._
+        |import io.circe._
+        |import org.http4s._
+        |import org.http4s.client.Client
+        |import org.http4s.client.blaze._
+        |import org.http4s.circe._
+        |import org.http4s.Status.Successful
+        |import shapeless.Coproduct
+        |import scala.concurrent.ExecutionContext
+        |import petstore.PetstoreClient
+        |import petstore.models._
+        |object PetstoreHttpClient {
+        |
+        |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
+        |    import PetstoreClient._
+        |$defaultImplicits
+        |    def createPayloads(xAuth: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads).withHeaders(Headers(Header("X-Auth", xAuth.show), Header("token", token.show)))) {
+        |      case Successful(response) => response.as[Unit].map(_.asRight)
+        |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
+        |    }
+        |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withBody(payloads))
+        |  }
+        |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext, $timeQueryParamEncoders): F[PetstoreClient[F]] = Http1Client[F](config = BlazeClientConfig.defaultConfig.copy(executionContext = executionContext)).map(PetstoreHttpClient.build(_, baseUrl))
+        |}""".stripMargin
       )
     }
   }
@@ -1240,6 +1280,9 @@ object OpenApiPrintSpecification {
         .withParameter(query("limit-for", Fixed.integer()))
     )
 
+  val modelImports =
+    """|import shapeless.{:+:, CNil}
+       |import shapeless.Coproduct""".stripMargin
   val defaultImplicits =
     """|    implicit def listEntityEncoder[T: Encoder]: EntityEncoder[F, List[T]] = jsonEncoderOf[F, List[T]]
        |    implicit def listEntityDecoder[T: Decoder]: EntityDecoder[F, List[T]] = jsonOf[F, List[T]]

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -57,6 +57,20 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |}""".stripMargin)
     }
+
+    "when a object type is provided with not a normalize shape" >> {
+      import Printer.avoid._
+      model.print(petstoreOpenApi.withSchema("212bar_Foo-X1" -> obj("foo" -> Fixed.string())())) must ===(
+        """|object models {
+           |
+           |final case class BarFooX1212(foo: Option[String])
+           |object BarFooX1212 {
+           |
+           |
+           |}
+           |}""".stripMargin)
+    }
+
     "when an array is provided" >> {
       import client.http4s.circe._
       model.print(
@@ -80,6 +94,21 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |}
            |}""".stripMargin)
+    }
+
+    "when a array type is provided with a not normalize shape" >> {
+      import Printer.avoid._
+      model.print(
+        petstoreOpenApi.withSchema(
+          "bar_Foo-X1s" -> Fixed.array(Fixed.reference("#/components/schemas/bar_Foo-X1"))
+        )) must ===("""|object models {
+             |
+             |type BarFooX1s = List[BarFooX1]
+             |object BarFooX1s {
+             |
+             |
+             |}
+             |}""".stripMargin)
     }
 
     "when enum is provided" >> {
@@ -117,7 +146,22 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}
            |}""".stripMargin
       )
+    }
 
+    "when enum is provided with a not normalize shape" >> {
+      import Printer.avoid._
+      model.print(petstoreOpenApi.withSchema("something-For" -> Fixed.enum(List("xxx", "yyy")))) must ===(
+        """|object models {
+             |
+             |sealed trait SomethingFor
+             |object SomethingFor {
+             |
+             |  final case object xxx extends SomethingFor
+             |  final case object yyy extends SomethingFor
+             |
+             |}
+             |}""".stripMargin
+      )
     }
 
     "when multiple types are provided" >> {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -614,9 +614,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(petstoreOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         s"""|object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def deletePayload(id: String): F[Unit] = client.expect[Unit](Request[F](method = Method.DELETE, uri = baseUrl / "payloads" / id.show))
            |    def updatePayload(id: String, updatePayload: UpdatePayload): F[Unit] = client.expect[Unit](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show).with(updatePayload))
            |  }
@@ -628,9 +628,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(petstoreOpenApi.withPath(mediaTypeReferenceGet).withPath(mediaTypeReferenceGetId)) must ===(
         s"""|object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def getPayload(limit: Option[Int], name: Option[String]): F[Payloads] = client.expect[Payloads](Request[F](method = Method.GET, uri = baseUrl / "payloads" +?? ("limit", limit) +?? ("name", name)))
            |    def getPayload(id: String): F[Payload] = client.expect[Payload](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show))
            |  }
@@ -643,9 +643,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(petstoreOpenApi.withPath(mediaTypeOptionBody)) must ===(
         s"""|object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def deletePayload(id: String, size: Long, updatePayload: Option[UpdatePayload]): F[Unit] = client.expect[Unit](Request[F](method = Method.DELETE, uri = baseUrl / "payloads" / id.show +? ("size", size)).with(updatePayload))
            |  }
            |
@@ -657,9 +657,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(petstoreOpenApi.withPath(references)) must ===(
         s"""|object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def updatePayload(updatePayload: UpdatePayload): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads").with(updatePayload))
            |  }
            |
@@ -671,9 +671,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(petstoreOpenApi.withPath(multipleResponsesWithDefaultOne)) must ===(
         s"""|object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[Payload].map(_.asRight)
            |      case default => default.as[Error].map(x => GetPayloadUnexpectedErrorResponse(default.status.code, x).asLeft)
@@ -686,9 +686,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when there are multiple responses with not found response" >> {
       implDefinition.print(petstoreOpenApi.withPath(notFoundResponse)) must ===(s"""|object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def getPayload(id: String): F[Either[GetPayloadError, Payload]] = client.fetch[Either[GetPayloadError, Payload]](Request[F](method = Method.GET, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[Payload].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[String].map(x => GetPayloadNotFoundError(x).asLeft)
@@ -702,9 +702,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(petstoreOpenApi.withPath(simpleResponseResponseAnonymousObjects)) must ===(
         s"""|object PetstoreHttpClient {
           |
-          |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+          |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
           |    import PetstoreClient._
-          |$listImplicits
+          |$listCodecsImplicits
           |    def updateAnotherPayload(id: String, updateAnotherPayloadRequest: UpdateAnotherPayloadRequest): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show).with(updateAnotherPayloadRequest))
           |  }
           |
@@ -715,9 +715,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObjectAndDefaultOne)) must ===(
         s"""|object PayloadHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]] = client.fetch[Either[UpdatePayloadError, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[UpdatedPayload].map(_.asRight)
            |      case default => default.as[UpdatePayloadUnexpectedError].map(x => UpdatePayloadUnexpectedErrorResponse(default.status.code, x).asLeft)
@@ -731,9 +731,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(payloadOpenApi.withPath(multipleResponses)) must ===(
         s"""|object PayloadHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def createPayload(): F[Either[CreatePayloadError, Unit]] = client.fetch[Either[CreatePayloadError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[String].map(x => Coproduct[CreatePayloadError](CreatePayloadNotFoundError(x)).asLeft)
@@ -749,9 +749,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(payloadOpenApi.withPath(multipleResponsesWithAnonymousObject)) must ===(
         s"""|object PayloadHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def updatePayload(id: String): F[Either[UpdatePayloadError, UpdatedPayload]] = client.fetch[Either[UpdatePayloadError, UpdatedPayload]](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show)) {
            |      case Successful(response) => response.as[UpdatedPayload].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[UpdatePayloadNotFound].map(x => x.asLeft)
@@ -766,9 +766,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(payloadOpenApi.withPath(emptyErrorResponse)) must ===(
         s"""|object PayloadHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def deletePayloads(): F[Either[DeletePayloadsError, Unit]] = client.fetch[Either[DeletePayloadsError, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[Unit].map(x => DeletePayloadsNotFoundError(x).asLeft)
@@ -783,9 +783,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(payloadOpenApi.withPath(multipleEmptyErrorResponse)) must ===(
         s"""|object PayloadHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def deletePayloads(): F[Either[DeletePayloadsError, Unit]] = client.fetch[Either[DeletePayloadsError, Unit]](Request[F](method = Method.DELETE, uri = baseUrl / "payloads")) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case response if response.status.code == 404 => response.as[Unit].map(x => Coproduct[DeletePayloadsError](DeletePayloadsNotFoundError(x)).asLeft)
@@ -802,9 +802,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       implDefinition.print(payloadOpenApi.withPath(notNormalizeRequest)) must ===(
         s"""|object PayloadHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PayloadClient[F] = new PayloadClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def get1id(id1: String, limitFor: Option[Int], listString: List[String]): F[Unit] = client.expect[Unit](Request[F](method = Method.GET, uri = baseUrl / "1id" / id1.show +?? ("limit-for", limitFor)).with(listString))
            |  }
            |
@@ -837,16 +837,16 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import petstore.models._
            |object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads)) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
            |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withEntity(payloads))
            |  }
-           |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext): Resource[F, PetstoreClient[F]] = BlazeClientBuilder(executionContext).resource.map(PetstoreHttpClient.build(_, baseUrl))
+           |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext, $timeQueryParamEncoders): Resource[F, PetstoreClient[F]] = BlazeClientBuilder(executionContext).resource.map(PetstoreHttpClient.build(_, baseUrl))
            |}""".stripMargin
       )
     }
@@ -873,16 +873,16 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import petstore.models._
            |object PetstoreHttpClient {
            |
-           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri): PetstoreClient[F] = new PetstoreClient[F] {
+           |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
            |    import PetstoreClient._
-           |$listImplicits
+           |$listCodecsImplicits
            |    def createPayloads(newPayloads: NewPayloads): F[Either[CreatePayloadsError, Unit]] = client.fetch[Either[CreatePayloadsError, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads)) {
            |      case Successful(response) => response.as[Unit].map(_.asRight)
            |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
            |    }
            |    def updatePayloads(payloads: Payloads): F[Payloads] = client.expect[Payloads](Request[F](method = Method.PUT, uri = baseUrl / "payloads").withBody(payloads))
            |  }
-           |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext): F[PetstoreClient[F]] = Http1Client[F](config = BlazeClientConfig.defaultConfig.copy(executionContext = executionContext)).map(PetstoreHttpClient.build(_, baseUrl))
+           |  def apply[F[_]: ConcurrentEffect](baseUrl: Uri)(implicit executionContext: ExecutionContext, $timeQueryParamEncoders): F[PetstoreClient[F]] = Http1Client[F](config = BlazeClientConfig.defaultConfig.copy(executionContext = executionContext)).map(PetstoreHttpClient.build(_, baseUrl))
            |}""".stripMargin
       )
     }
@@ -1088,10 +1088,15 @@ object OpenApiPrintSpecification {
         .withParameter(query("limit-for", Fixed.integer()))
     )
 
-  val listImplicits =
+  val listCodecsImplicits =
     """|    implicit def listEntityEncoder[T: Encoder]: EntityEncoder[F, List[T]] = jsonEncoderOf[F, List[T]]
        |    implicit def listEntityDecoder[T: Decoder]: EntityDecoder[F, List[T]] = jsonOf[F, List[T]]
        |    implicit def optionListEntityEncoder[T: Encoder]: EntityEncoder[F, Option[List[T]]] = jsonEncoderOf[F, Option[List[T]]]
        |    implicit def optionListEntityDecoder[T: Decoder]: EntityDecoder[F, Option[List[T]]] = jsonOf[F, Option[List[T]]]""".stripMargin
+
+  val timeQueryParamEncoders =
+    "localDateTimeQueryEncoder: QueryParamEncoder[java.time.LocalDateTime], localDateQueryEncoder: QueryParamEncoder[java.time.LocalDate]"
+  val timeQueryParamEncodersImplicit =
+    s"implicit $timeQueryParamEncoders"
 
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
@@ -23,14 +23,15 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
 
   import cats.implicits._
   import OperationIdSpecification._
+  import Http._
 
   "operation id should able normalize" >> {
 
     "when a description is provided" >> {
       OperationId(
         (
-          HttpVerb.Put,
-          HttpPath("/foo"),
+          Verb.Put,
+          Path("/foo"),
           defaultOperation.withOperationId("createPayload")
         )
       ).show must ===("createPayload")
@@ -39,8 +40,8 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
     "when a description is not provided" >> {
       OperationId(
         (
-          HttpVerb.Put,
-          HttpPath("/foo"),
+          Verb.Put,
+          Path("/foo"),
           defaultOperation
         )
       ).show must ===("updateFoo")
@@ -49,8 +50,8 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
     "when the description contains special characters" >> {
       OperationId(
         (
-          HttpVerb.Put,
-          HttpPath("/foo"),
+          Verb.Put,
+          Path("/foo"),
           defaultOperation.withOperationId("create-Payload_V1")
         )
       ).show must ===("createPayloadV1")
@@ -59,8 +60,8 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
     "when the description is not provided and contains special characters" >> {
       OperationId(
         (
-          HttpVerb.Get,
-          HttpPath("/v1/pet-details_eager"),
+          Verb.Get,
+          Path("/v1/pet-details_eager"),
           defaultOperation
         )
       ).show must ===("getPetDetailsEagerV1")
@@ -69,8 +70,8 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
     "when the path contains query params" >> {
       OperationId(
         (
-          HttpVerb.Delete,
-          HttpPath("/pets/{petId}/owners"),
+          Verb.Delete,
+          Path("/pets/{petId}/owners"),
           defaultOperation
         )
       ).show must ===("deleteOwnersPets")
@@ -79,8 +80,8 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
     "when a description is provided with numbers at the beginning" >> {
       OperationId(
         (
-          HttpVerb.Put,
-          HttpPath("/foo"),
+          Verb.Put,
+          Path("/foo"),
           defaultOperation.withOperationId("1111createPayload")
         )
       ).show must ===("createPayload1111")

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.skeuomorph.openapi
+
+import higherkindness.skeuomorph.openapi.client.print._
+import helpers._
+
+class OperationIdSpecification extends org.specs2.mutable.Specification {
+
+  import cats.implicits._
+  import OperationIdSpecification._
+
+  "operation id should able normalize" >> {
+
+    "when a description is provided" >> {
+      OperationId(
+        (
+          HttpVerb.Put,
+          HttpPath("/foo"),
+          defaultOperation.withOperationId("createPayload")
+        )
+      ).show must ===("createPayload")
+    }
+
+    "when a description is not provided" >> {
+      OperationId(
+        (
+          HttpVerb.Put,
+          HttpPath("/foo"),
+          defaultOperation
+        )
+      ).show must ===("updateFoo")
+    }
+
+    "when the description contains special characters" >> {
+      OperationId(
+        (
+          HttpVerb.Put,
+          HttpPath("/foo"),
+          defaultOperation.withOperationId("create-Payload_V1")
+        )
+      ).show must ===("createPayloadV1")
+    }
+
+    "when the description is not provided and contains special characters" >> {
+      OperationId(
+        (
+          HttpVerb.Get,
+          HttpPath("/v1/pet-details_eager"),
+          defaultOperation
+        )
+      ).show must ===("getPetDetailsEagerV1")
+    }
+
+    "when the path contains query params" >> {
+      OperationId(
+        (
+          HttpVerb.Delete,
+          HttpPath("/pets/{petId}/owners"),
+          defaultOperation
+        )
+      ).show must ===("deleteOwnersPets")
+    }
+  }
+}
+object OperationIdSpecification {
+  import JsonSchemaF.Fixed
+  val defaultOperation = operation[JsonSchemaF.Fixed](
+    request("application/json" -> mediaType(Fixed.reference("#/components/schemas/Foo"))),
+    responses = "201"          -> response("Null response")
+  )
+}

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
@@ -29,61 +29,57 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
 
     "when a description is provided" >> {
       OperationId(
-        (
-          Verb.Put,
-          Path("/foo"),
-          defaultOperation.withOperationId("createPayload")
-        )
+        Verb.Put,
+        Path("/foo"),
+        defaultOperation.withOperationId("createPayload")
       ).show must ===("createPayload")
     }
 
     "when a description is not provided" >> {
       OperationId(
-        (
-          Verb.Put,
-          Path("/foo"),
-          defaultOperation
-        )
+        Verb.Put,
+        Path("/foo"),
+        defaultOperation
       ).show must ===("updateFoo")
     }
 
     "when the description contains special characters" >> {
       OperationId(
-        (
-          Verb.Put,
-          Path("/foo"),
-          defaultOperation.withOperationId("create-Payload_V1")
-        )
+        Verb.Put,
+        Path("/foo"),
+        defaultOperation.withOperationId("create-Payload_V1")
       ).show must ===("createPayloadV1")
     }
 
     "when the description is not provided and contains special characters" >> {
       OperationId(
-        (
-          Verb.Get,
-          Path("/v1/pet-details_eager"),
-          defaultOperation
-        )
+        Verb.Get,
+        Path("/v1/pet-details_eager"),
+        defaultOperation
       ).show must ===("getPetDetailsEagerV1")
+    }
+
+    "when the path contains path variables" >> {
+      OperationId(
+        Verb.Delete,
+        Path("/pets/{petId}/owners"),
+        defaultOperation
+      ).show must ===("deleteOwnersPetsByPetId")
     }
 
     "when the path contains query params" >> {
       OperationId(
-        (
-          Verb.Delete,
-          Path("/pets/{petId}/owners"),
-          defaultOperation
-        )
-      ).show must ===("deleteOwnersPets")
+        Verb.Delete,
+        Path("/pets/{petId}/owners?userId={userId}&name={name}"),
+        defaultOperation
+      ).show must ===("deleteOwnersPetsByPetIdUserIdName")
     }
 
     "when a description is provided with numbers at the beginning" >> {
       OperationId(
-        (
-          Verb.Put,
-          Path("/foo"),
-          defaultOperation.withOperationId("1111createPayload")
-        )
+        Verb.Put,
+        Path("/foo"),
+        defaultOperation.withOperationId("1111createPayload")
       ).show must ===("createPayload1111")
     }
   }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
@@ -75,6 +75,16 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
         )
       ).show must ===("deleteOwnersPets")
     }
+
+    "when a description is provided with numbers at the beginning" >> {
+      OperationId(
+        (
+          HttpVerb.Put,
+          HttpPath("/foo"),
+          defaultOperation.withOperationId("1111createPayload")
+        )
+      ).show must ===("createPayload1111")
+    }
   }
 }
 object OperationIdSpecification {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
@@ -130,9 +130,9 @@ object helpers {
     Components(schemas = models.toMap, responses = Map.empty, requestBodies = Map.empty, parameters = Map.empty)
 
   implicit class ComponentsOps[T](components: Components[T]) {
-    def addParameter(name: String, parameter: Parameter[T]): Components[T] =
+    def withParameter(name: String, parameter: Parameter[T]): Components[T] =
       components.copy(parameters = components.parameters + (name -> parameter.asLeft))
-    def addSchema(name: String, t: T): Components[T] =
+    def withSchema(name: String, t: T): Components[T] =
       components.copy(schemas = components.schemas + (name -> t))
 
   }
@@ -152,7 +152,12 @@ object helpers {
       openApi.copy(paths = openApi.paths.+(path))
     def withSchema(name: String, a: A): OpenApi[A] =
       openApi.copy(
-        components = openApi.components.fold(components(name -> a))(_.addSchema(name, a)).some
+        components = openApi.components.fold(components(name -> a))(_.withSchema(name, a)).some
+      )
+    def withParameter(name: String, parameter: Parameter[A]): OpenApi[A] =
+      openApi.copy(
+        components =
+          openApi.components.fold(components().withParameter(name, parameter))(_.withParameter(name, parameter)).some
       )
   }
 

--- a/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
@@ -79,6 +79,13 @@ object helpers {
     def optional: Request[A]                             = request.copy(required = false)
   }
 
+  def header[A](
+      name: String,
+      schema: A,
+      description: Option[String] = None,
+      required: Boolean = true): Parameter.Header[A] =
+    Parameter.Header(name, description, schema = schema, required = required)
+
   def path[A](name: String, schema: A, description: Option[String] = None): Parameter[A] =
     Parameter.Path(name = name, description = description, schema = schema)
   def query[A](

--- a/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
@@ -127,7 +127,15 @@ object helpers {
   }
 
   def components[T](models: (String, T)*): Components[T] =
-    Components(schemas = models.toMap, responses = Map.empty, requestBodies = Map.empty)
+    Components(schemas = models.toMap, responses = Map.empty, requestBodies = Map.empty, parameters = Map.empty)
+
+  implicit class ComponentsOps[T](components: Components[T]) {
+    def addParameter(name: String, parameter: Parameter[T]): Components[T] =
+      components.copy(parameters = components.parameters + (name -> parameter.asLeft))
+    def addSchema(name: String, t: T): Components[T] =
+      components.copy(schemas = components.schemas + (name -> t))
+
+  }
 
   def openApi[A](name: String, version: String = "0.0.0"): OpenApi[A] = OpenApi(
     openapi = "",
@@ -142,9 +150,9 @@ object helpers {
   implicit class OpenApiOps[A](openApi: OpenApi[A]) {
     def withPath(path: (String, Path.ItemObject[A])): OpenApi[A] =
       openApi.copy(paths = openApi.paths.+(path))
-    def withSchema(model: (String, A)): OpenApi[A] =
+    def withSchema(name: String, a: A): OpenApi[A] =
       openApi.copy(
-        components = openApi.components.fold(components(model))(x => x.copy(x.schemas + model)).some
+        components = openApi.components.fold(components(name -> a))(_.addSchema(name, a)).some
       )
   }
 

--- a/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
@@ -110,7 +110,8 @@ object helpers {
     head = None,
     patch = None,
     trace = None,
-    servers = List.empty
+    servers = List.empty,
+    parameters = List.empty
   )
 
   def obj(properties: (String, JsonSchemaF.Fixed)*)(required: String*): JsonSchemaF.Fixed =
@@ -124,6 +125,8 @@ object helpers {
       item.copy(post = operation.some)
     def withGet(operation: Path.Operation[A]): Path.ItemObject[A] =
       item.copy(get = operation.some)
+    def withParameter(parameter: Parameter[A]): Path.ItemObject[A] =
+      item.copy(parameters = item.parameters :+ parameter.asLeft)
   }
 
   def components[T](models: (String, T)*): Components[T] =


### PR DESCRIPTION
# Objective
You can find, the objectives for all these PRs here: https://github.com/47deg/marlow/issues/188
> Generating http4s client code based on a Open API specification using http4s v0.20 and 0.18 using circe to encode/decode.

# Normalize
**Open api spec** is based on _http_ and is not in a specific programming language. Names of different type of elements (e.g.: schema names, property names, reference names, etc.) can contain symbols, numbers, etc. or grammar rules that are not allowed in the target programming language (in this case _scala_) when we are generating code.  This could be problematic because we are generating code that it is not able to compile.
```yaml
components:
  schemas:
    general-error:
      type: object
      properties:
        code:
          type: integer
          format: int32
        message:
          type: string
    category:
      type: object
      properties:
        id:
          type: integer
          format: int64
        name:
          type: string
    tag:
      type: object
      properties:
        id:
          type: integer
          format: int64
        tag_name:
          type: string
```

This is going to be another problem for **encoder/decoders** because there is a mismatch between the _http protocol_ and the _scala_ model. This gap needs to be addressed during the generation of the **encoders/decoders** code.

# Request headers
 **Open api spec** provides a way to define headers in the request.
```yaml
name: token
in: header
description: token to be passed as a header
required: true
schema:
  type: array
  items:
    type: integer
    format: int64
style: simple
```
# Parameters
 **Open api spec** provides a way to define parameter at different levels.
## Components
We can share parameters for different requests in your definition and we can refer to them using `#/components/parameters/{param_name}` when _param_name_ is the name of the parameter.
```yaml
components:
 parameters:
    offsetParam:      # Can be referenced via '#/components/parameters/offsetParam'
      name: offset
      in: query
      description: Number of items to skip before returning the results.
      required: false
      schema:
        type: integer
        format: int32
        minimum: 0
        default: 0
    limitParam:       # Can be referenced as '#/components/parameters/limitParam'
      name: limit
      in: query
      description: Maximum number of items to return.
      required: false
      schema:
        type: integer
        format: int32
        minimum: 1
        maximum: 100
        default: 20
```

## Path Item Object
We can share parameters for all the operations defined at the path item object level.

```yaml
get:
  description: Returns pets based on ID
  summary: Find pets by ID
  operationId: getPetsById
  responses:
    '200':
      description: pet response
      content:
        '*/*' :
          schema:
            type: array
            items:
              $ref: '#/components/schemas/Pet'
    default:
      description: error payload
      content:
        'text/html':
          schema:
            $ref: '#/components/schemas/ErrorModel'
parameters:
- name: id
  in: path
  description: ID of pet to use
  required: true
  schema:
    type: array
    style: simple
    items:
      type: string 
```
# Implicit Time query parameter
When we have a query parameter that is from the`java.time` package it is required to provide implicitly `QueryParamEncoder`. For the following example, we should provide `QueryParamEncoder[java.time.LocalDate]` :
```scala
def getUsers(
            startDate: Option[java.time.LocalDate]): F[List[User]] =
          client.expect[List[User]](
            Request[F](
              method = Method.GET,
              uri = baseUrl / "v0" / "users" +?? ("startDate", startDate)
            ))
```

# Sum types
**Open api spec** provides a way to define a sum type. Here is an example.
```yaml
 - Vehicle:
      oneOf:
        - $ref: "#/components/schemas/Car"
        - $ref: "#/components/schemas/Boat"
        - $ref: "#/components/schemas/Ship"
```

This needs to be supported at all levels.

# Previous PRs
- https://github.com/higherkindness/skeuomorph/pull/116
- https://github.com/higherkindness/skeuomorph/pull/109
- https://github.com/higherkindness/skeuomorph/pull/102
- https://github.com/higherkindness/skeuomorph/pull/97
- https://github.com/higherkindness/skeuomorph/pull/90
- https://github.com/higherkindness/skeuomorph/pull/81