### PR TITLE
Open api parser

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val commonSettings = Seq(
     "io.circe"            %% "circe-testing" % V.circe % Test,
     %%("cats-effect", V.catsEffect),
     %%("circe-core", V.circe),
-    %%("circe-parser", V.circe)       % Test,
+    %%("circe-parser", V.circe)       ,
     %%("scalacheck", V.scalacheck)    % Test,
     %%("specs2-core", V.specs2)       % Test,
     %%("specs2-scalacheck", V.specs2) % Test,

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -319,7 +319,7 @@ object JsonDecoders {
           openapi: String,
           info: Info,
           servers: Option[List[Server]],
-          paths: Map[String, Path.ItemObject[A]],
+          paths: Option[Map[String, Path.ItemObject[A]]],
           components: Option[Components[A]],
           tags: Option[List[Tag]],
           externalDocs: Option[ExternalDocs]) =>
@@ -327,7 +327,7 @@ object JsonDecoders {
           openapi,
           info,
           servers.getOrElse(List.empty),
-          paths,
+          paths.getOrElse(Map.empty),
           components,
           tags.getOrElse(List.empty),
           externalDocs))

--- a/src/main/scala/higherkindness/skeuomorph/openapi/ParseOpenApi.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/ParseOpenApi.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.skeuomorph.openapi
+
+import java.io.File
+
+import qq.droste._
+import higherkindness.skeuomorph.Parser
+import schema.OpenApi
+import cats.effect.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.either._
+
+object ParseOpenApi {
+  import JsonDecoders._
+
+  case class YamlSource(file: File)
+  case class JsonSource(file: File)
+
+  implicit def parseYamlOpenApi[F[_], T](implicit T: Embed[JsonSchemaF, T]): Parser[F, YamlSource, OpenApi[T]] =
+    new Parser[F, YamlSource, OpenApi[T]] {
+      import yaml.{Decoder => _, _}
+      override def parse(input: YamlSource)(implicit S: Sync[F]): F[OpenApi[T]] =
+        readContent(input.file).flatMap(
+          x =>
+            S.fromEither(
+              yaml
+                .Decoder[OpenApi[T]]
+                .apply(x)
+                .left
+                .map(_.valueOr(identity))
+          )
+        )
+    }
+
+  implicit def parseJsonOpenApi[F[_], T](implicit T: Embed[JsonSchemaF, T]): Parser[F, JsonSource, OpenApi[T]] =
+    new Parser[F, JsonSource, OpenApi[T]] {
+      import io.circe.Decoder
+      import io.circe.parser
+
+      override def parse(input: JsonSource)(implicit S: Sync[F]): F[OpenApi[T]] =
+        for {
+          content <- readContent(input.file)
+          json    <- S.fromEither(parser.parse(content))
+          openApi <- S.fromEither(Decoder[OpenApi[T]].decodeJson(json))
+        } yield openApi
+    }
+
+  private def readContent[F[_]: Sync](file: File): F[String] = Sync[F].delay {
+    scala.io.Source
+      .fromFile(file)
+      .getLines()
+      .toList
+      .mkString("\n")
+  }
+
+}

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -460,12 +460,13 @@ object print {
   }
 
   def interfaceDefinition[T: Basis[JsonSchemaF, ?]](implicit codecs: Printer[Codecs]): Printer[OpenApi[T]] =
-    (
-      sepBy(importDef, "\n") >* newLine,
-      κ("trait ") *< show[TraitName] >* κ("[F[_]] {") >* newLine,
-      space *< space *< κ("import ") *< show[TraitName] >* κ("._") >* newLine,
-      sepBy(method[T], "\n") >* (newLine >* κ("}") >* newLine),
-      objectDef(clientTypes[T] >* newLine)
-    ).contramapN(operationsTuple[T])
+    optional(
+      (
+        sepBy(importDef, "\n") >* newLine,
+        κ("trait ") *< show[TraitName] >* κ("[F[_]] {") >* newLine,
+        space *< space *< κ("import ") *< show[TraitName] >* κ("._") >* newLine,
+        sepBy(method[T], "\n") >* (newLine >* κ("}") >* newLine),
+        objectDef(clientTypes[T] >* newLine)
+      ).contramapN(operationsTuple[T])).contramap(x => x.paths.toList.headOption.map(_ => x))
 
 }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -179,11 +179,15 @@ object print {
   }
 
   def model[T: Basis[JsonSchemaF, ?]](implicit codecs: Printer[Codecs]): Printer[OpenApi[T]] =
-    objectDef(sepBy(schemaWithName, "\n")).contramap { x =>
-      (
-        ("models", none),
-        (List("shapeless.{:+:, CNil}", "shapeless.Coproduct") ++ sumTypes(x).map(x => s"$x._")).map(PackageName.apply),
-        x.components.toList.flatMap(_.schemas))
+    optional(objectDef(sepBy(schemaWithName, "\n"))).contramap { x =>
+      val models = x.components.toList.flatMap(_.schemas)
+      models.headOption.map(
+        _ =>
+          (
+            ("models", none),
+            (List("shapeless.{:+:, CNil}", "shapeless.Coproduct") ++ sumTypes(x).map(x => s"$x._"))
+              .map(PackageName.apply),
+            x.components.toList.flatMap(_.schemas)))
     }
 
   private def sumDef(implicit codecs: Printer[Codecs]): Printer[(String, List[String])] =

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
@@ -306,6 +306,29 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
         "info" : {
           "title": "Swagger Petstore",
           "version": "1.0.0"
+        }
+      }
+      """)
+
+      Decoder[OpenApi[JsonSchemaF.Fixed]].decodeJson(json) must beRight(
+        OpenApi[JsonSchemaF.Fixed](
+          "3.0.0",
+          Info("Swagger Petstore", None, "1.0.0"),
+          List.empty,
+          Map.empty,
+          None,
+          List.empty,
+          None
+        ))
+    }
+
+    "when paths are provided" >> {
+      val json = unsafeParse("""
+      {
+        "openapi" : "3.0.0",
+        "info" : {
+          "title": "Swagger Petstore",
+          "version": "1.0.0"
         },
         "paths": {
           "/pets": {

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -26,6 +26,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
   import OpenApiPrintSpecification._
 
   "models should able to print" >> {
+    "when not types are provided" >> {
+      import client.http4s.circe._
+      model.print(petstoreOpenApi) must ===("")
+    }
     "when a basic type is provided" >> {
       import client.http4s.circe._
       model.print(petstoreOpenApi.withSchema("Foo", Fixed.string())) must
@@ -242,6 +246,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
   "Client trait should able to print" >> {
     import client.print._
+    "when there are no paths" >> {
+      import client.http4s.circe._
+      interfaceDefinition.print(payloadOpenApi) must ===("")
+    }
 
     "when a post operation is provided" >> {
       import client.http4s.circe._
@@ -740,6 +748,10 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
 
     }
 
+    "when there are no paths" >> {
+      implDefinition.print(petstoreOpenApi) must ===("")
+    }
+
     "when a put and delete are provided" >> {
       implDefinition.print(petstoreOpenApi.withPath(mediaTypeReferencePutDelete)) must ===(
         s"""|object PetstoreHttpClient {
@@ -1040,6 +1052,14 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
         |}""".stripMargin
       )
     }
+
+    "when there are no paths" >> {
+      import client.http4s.print.impl
+      import client.http4s.print.v18._
+      import Printer.avoid._
+      impl.print(PackageName("petstore") -> petstoreOpenApi) must ===("")
+    }
+
   }
 }
 


### PR DESCRIPTION
# Objective
You can find, the objectives for all these PRs here: https://github.com/47deg/marlow/issues/188
> Generating http4s client code based on a Open API specification using http4s v0.20 and 0.18 using circe to encode/decode.

# Open Api Parser
It will require to create the `Parser` instances for _yaml_ and _json_. This will simplify the use the library and it will be required for *mu* project. We can create an instance for _json_ as following:

```scala
Parser[F, JsonSource, OpenApi[JsonSchemaF.Fixed]]
```
# Avoid printing
There are some situation we should not print anything. 
- We should print empty string for *models* when the *components / schemas* they don't provide any schemas.
- We should print empty string for *interface / implementation* when there are not paths defined.



# Previous PRs
- https://github.com/higherkindness/skeuomorph/pull/121
- https://github.com/higherkindness/skeuomorph/pull/116
- https://github.com/higherkindness/skeuomorph/pull/109
- https://github.com/higherkindness/skeuomorph/pull/102
- https://github.com/higherkindness/skeuomorph/pull/97
- https://github.com/higherkindness/skeuomorph/pull/90
- https://github.com/higherkindness/skeuomorph/pull/81