### PR TITLE
Exhaustive protobuf tests

### DIFF
--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -32,7 +32,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
   val root                                      = "/src/test/scala/higherkindness/skeuomorph/protobuf"
   val path                                      = currentDirectory + s"$root/service"
   val importRoot                                = Some(currentDirectory + root)
-  val source                                    = ProtoSource(s"book.proto", path, importRoot)
+  val source                                    = ProtoSource(s"bookService.proto", path, importRoot)
   val protobufProtocol: Protocol[Mu[ProtobufF]] = parseProto[IO, Mu[ProtobufF]].parse(source).unsafeRunSync()
 
   implicit val arbCompressionType: Arbitrary[CompressionType] = Arbitrary {

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -28,12 +28,10 @@ import higherkindness.droste.data.Mu._
 
 class ProtobufProtocolSpec extends Specification with ScalaCheck {
 
-  val currentDirectory: String                  = new java.io.File(".").getCanonicalPath
-  val root                                      = "/src/test/scala/higherkindness/skeuomorph/protobuf"
-  val path                                      = currentDirectory + s"$root/service"
-  val importRoot                                = Some(currentDirectory + root)
-  val source                                    = ProtoSource(s"bookService.proto", path, importRoot)
-  val protobufProtocol: Protocol[Mu[ProtobufF]] = parseProto[IO, Mu[ProtobufF]].parse(source).unsafeRunSync()
+  val currentDirectory: String = new java.io.File(".").getCanonicalPath
+  val root                     = "/src/test/scala/higherkindness/skeuomorph/protobuf"
+  val path                     = currentDirectory + s"$root/service"
+  val importRoot               = Some(currentDirectory + root)
 
   implicit val arbCompressionType: Arbitrary[CompressionType] = Arbitrary {
     Gen.oneOf(CompressionType.Identity, CompressionType.Gzip)
@@ -41,12 +39,14 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
 
   def is = s2"""
   Protobuf Protocol
-
-  It should be possible to print a protocol from a Proto file. $printProtobufProtocol
-
+  It prints models from a models Proto file. ${printModelProtobufProtocol("book")}
+  It prints a service from a service Proto file. ${printServiceProtobufProtocol("bookService")}
   """
 
-  def printProtobufProtocol = prop { (ct: CompressionType, useIdiom: Boolean) =>
+  def parseProtobufProtocol(fileName: String)(ct: CompressionType, useIdiom: Boolean) = {
+    val source                                    = ProtoSource(s"$fileName.proto", path, importRoot)
+    val protobufProtocol: Protocol[Mu[ProtobufF]] = parseProto[IO, Mu[ProtobufF]].parse(source).unsafeRunSync()
+
     val parseProtocol: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] = {
       p: Protocol[Mu[ProtobufF]] =>
         higherkindness.skeuomorph.mu.Protocol.fromProtobufProto(ct, useIdiom)(p)
@@ -57,49 +57,86 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
         higherkindness.skeuomorph.mu.print.proto.print(p)
     }
 
-    (parseProtocol andThen printProtocol)(protobufProtocol).clean must beEqualTo(expectation(ct, useIdiom).clean)
+    (parseProtocol andThen printProtocol)(protobufProtocol)
   }
 
-  def expectation(compressionType: CompressionType, useIdiomaticEndpoints: Boolean): String = {
+  def printModelProtobufProtocol(fileName: String) = prop { (ct: CompressionType, useIdiom: Boolean) =>
+    val result = parseProtobufProtocol(fileName)(ct, useIdiom)
+    println(s"\n${result}\n")
 
-    val serviceParams: String = "Protobuf" +
-      (if (compressionType == CompressionType.Gzip) ", Gzip" else ", Identity") +
-      (if (useIdiomaticEndpoints) ", namespace = Some(\"com.acme\"), methodNameStyle = Capitalize" else "")
+    result.clean must beEqualTo(modelsExpectation.clean)
+  }
 
-    s"""package com.acme
+  def printServiceProtobufProtocol(fileName: String) = prop { (ct: CompressionType, useIdiom: Boolean) =>
+    val result = parseProtobufProtocol(fileName)(ct, useIdiom)
+
+    result.clean must beEqualTo(serviceExpectation(ct, useIdiom).clean)
+  }
+
+  val modelsExpectation: String =
+    """package com.acme
       |
       |import com.acme.author.Author
       |import com.acme.rating.Rating
       |
       |object book {
       |
-      |@message final case class Book(isbn: Long, title: String, author: List[Option[Author]], binding_type: Option[BindingType], rating: Option[Rating])
-      |@message final case class GetBookRequest(isbn: Long)
-      |@message final case class GetBookViaAuthor(author: Option[Author])
-      |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Cop[Long :: Int :: String :: Book :: TNil])
+      |  sealed trait Genre
+      |  object Genre {
+      |    case object UNKNOWN extends Genre
+      |    case object SCIENCE_FICTION extends Genre
+      |    case object POETRY extends Genre
+      |  }
       |
-      |sealed trait Genre
-      |object Genre {
-      |  case object UNKNOWN extends Genre
-      |  case object SCIENCE_FICTION extends Genre
-      |  case object POETRY extends Genre
+      |  sealed trait BindingType
+      |  object BindingType {
+      |    case object HARDCOVER extends BindingType
+      |    case object PAPERBACK extends BindingType
+      |  }
+      |
+      |  @message final case class Book(isbn: Long, title: String, author: List[Author], binding_type: BindingType, rating: Rating)
+      |
+      |  @message final case class BookSeries(isbn: Long)
+      |
+      |  @message final case class Series(code: Long, name: String, numberOfBooks: Int, date: String, books: List[BookSeries])
+      |
+      |  @message final case class GetBookRequest(isbn: Long)
+      |
+      |  @message final case class GetBookViaAuthor(author: Author)
+      |
+      |  @message final case class GetBookSeries(isbn: Long)
+      |
+      |  @message final case class BookStore(name: String, books: Map[Long, String], genres: List[Genre], payment_method: Cop[Long :: Int :: String :: Book :: TNil])
+      |
       |}
-      |
-      |
-      |sealed trait BindingType
-      |object BindingType {
-      |  case object HARDCOVER extends BindingType
-      |  case object PAPERBACK extends BindingType
-      |}
-      |
-      |@service($serviceParams) trait BookService[F[_]] {
-      |  def GetBook(req: GetBookRequest): F[Book]
-      |  def GetBooksViaAuthor(req: GetBookViaAuthor): Stream[F, Book]
-      |  def GetGreatestBook(req: Stream[F, GetBookRequest]): F[Book]
-      |  def GetBooks(req: Stream[F, GetBookRequest]): Stream[F, Book]
-      |}
-      |
-      |}""".stripMargin
+      |""".stripMargin
+
+  def serviceExpectation(compressionType: CompressionType, useIdiomaticEndpoints: Boolean): String = {
+    val params: String =
+      "Protobuf" +
+        (if (compressionType == CompressionType.Gzip) ", Gzip" else ", Identity") +
+        (if (useIdiomaticEndpoints) ", namespace = Some(\"com.acme\"), methodNameStyle = Capitalize" else "")
+
+    s"""package com.acme
+       |
+       |import com.acme.book.Book
+       |import com.acme.book.Series
+       |import com.acme.book.GetBookRequest
+       |import com.acme.book.GetBookViaAuthor
+       |import com.acme.book.GetBookSeries
+       |import com.acme.book.BookStore
+       |
+       |object bookService {
+       |
+       |  @service($params) trait BookService[F[_]] {
+       |    def GetBook(req: GetBookRequest): F[Book]
+       |    def GetBooksSeries(req: GetBookSeries): F[Series]
+       |    def GetBooksViaAuthor(req: GetBookViaAuthor): Stream[F, Book]
+       |    def GetGreatestBook(req: Stream[F, GetBookRequest]): F[Book]
+       |    def GetBooks(req: Stream[F, GetBookRequest]): Stream[F, Book]
+       |  }
+       |
+       |}""".stripMargin
   }
 
   implicit class StringOps(self: String) {

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -62,6 +62,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
 
   def printModelProtobufProtocol(fileName: String) = prop { (ct: CompressionType, useIdiom: Boolean) =>
     val result = parseProtobufProtocol(fileName)(ct, useIdiom)
+    //TODO show unused import failure
     println(s"\n${result}\n")
 
     result.clean must beEqualTo(modelsExpectation.clean)
@@ -94,7 +95,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |    case object PAPERBACK extends BindingType
       |  }
       |
-      |  @message final case class Book(isbn: Long, title: String, author: List[Author], binding_type: BindingType, rating: Rating)
+      |  @message final case class Book(isbn: Long, title: String, book_genres: List[Genre], author: List[Author], `class`: BindingType, rating: Rating)
       |
       |  @message final case class BookSeries(isbn: Long)
       |

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/models/author.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/models/author.proto
@@ -3,6 +3,13 @@ syntax = "proto3";
 package com.acme;
 
 message Author {
-    string name = 1;
-    string nick = 2;
+  message Address {
+    string street = 1;
+    int32 number = 2;
+    string city = 4;
+    string country = 5;
+  }
+  string name = 1;
+  string nick = 2;
+  Address address = 3;
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/models/author.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/models/author.proto
@@ -3,13 +3,6 @@ syntax = "proto3";
 package com.acme;
 
 message Author {
-  message Address {
-    string street = 1;
-    int32 number = 2;
-    string city = 4;
-    string country = 5;
-  }
   string name = 1;
   string nick = 2;
-  Address address = 3;
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/rating.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/rating.proto
@@ -3,6 +3,6 @@ syntax = "proto3";
 package com.acme;
 
 message Rating {
-    int32 stars = 1;
-    uint32 reviews = 2;
+  int32 stars = 1;
+  uint32 reviews = 2;
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -6,53 +6,45 @@ import "models/author.proto";
 import "rating.proto";
 
 message Book {
-    reserved 4, 8;
-    reserved 12 to 15;
-    int64 isbn = 1;
-    string title = 2;
-    repeated Author author = 3;
-    BindingType binding_type = 9;
-    Rating rating = 10;
+  reserved 4, 8;
+  reserved 12 to 15;
+  int64 isbn = 1;
+  string title = 2;
+  repeated Author author = 3;
+  BindingType binding_type = 9;
+  Rating rating = 10;
 }
 
 message GetBookRequest {
-    int64 isbn = 1;
+  int64 isbn = 1;
 }
 
 message GetBookViaAuthor {
-    Author author = 1;
+  Author author = 1;
 }
-
-service BookService {
-    rpc GetBook (GetBookRequest) returns (Book) {}
-    rpc GetBooksViaAuthor (GetBookViaAuthor) returns (stream Book) {}
-    rpc GetGreatestBook (stream GetBookRequest) returns (Book) {}
-    rpc GetBooks (stream GetBookRequest) returns (stream Book) {}
-}
-
 message BookStore {
-    string name = 1;
-    map<int64, string> books = 2;
-    repeated Genre genres = 3;
+  string name = 1;
+  map<int64, string> books = 2;
+  repeated Genre genres = 3;
 
-    oneof payment_method {
-        int64 credit_card_number = 4;
-        int32 cash = 5;
-        string iou_note = 6;
-        Book barter = 7;
-    }
+  oneof payment_method {
+    int64 credit_card_number = 4;
+    int32 cash = 5;
+    string iou_note = 6;
+    Book barter = 7;
+  }
 }
 
 enum Genre {
-    option allow_alias = true;
-    UNKNOWN = 0;
-    SCIENCE_FICTION = 1;
-    SPECULATIVE_FICTION = 1;
-    POETRY = 2;
-    SCI_FI = 1;
+  option allow_alias = true;
+  UNKNOWN = 0;
+  SCIENCE_FICTION = 1;
+  SPECULATIVE_FICTION = 1;
+  POETRY = 2;
+  SCI_FI = 1;
 }
 
 enum BindingType {
-    HARDCOVER = 0;
-    PAPERBACK = 1;
+  HARDCOVER = 0;
+  PAPERBACK = 1;
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -5,36 +5,6 @@ package com.acme;
 import "models/author.proto";
 import "rating.proto";
 
-message Book {
-  reserved 4, 8;
-  reserved 12 to 15;
-  int64 isbn = 1;
-  string title = 2;
-  repeated Author author = 3;
-  BindingType binding_type = 9;
-  Rating rating = 10;
-}
-
-message GetBookRequest {
-  int64 isbn = 1;
-}
-
-message GetBookViaAuthor {
-  Author author = 1;
-}
-message BookStore {
-  string name = 1;
-  map<int64, string> books = 2;
-  repeated Genre genres = 3;
-
-  oneof payment_method {
-    int64 credit_card_number = 4;
-    int32 cash = 5;
-    string iou_note = 6;
-    Book barter = 7;
-  }
-}
-
 enum Genre {
   option allow_alias = true;
   UNKNOWN = 0;
@@ -47,4 +17,50 @@ enum Genre {
 enum BindingType {
   HARDCOVER = 0;
   PAPERBACK = 1;
+}
+
+message Book {
+  reserved 4, 8;
+  reserved 12 to 15;
+  int64 isbn = 1;
+  string title = 2;
+  repeated Author author = 3;
+  BindingType binding_type = 9;
+  Rating rating = 10;
+}
+
+message Series {
+  message BookSeries {
+    string isbn = 1;
+  }
+  int64 code = 1;
+  string name = 2;
+  int32 numberOfBooks = 3;
+  string date = 4;
+  repeated BookSeries books = 5;
+}
+
+message GetBookRequest {
+  int64 isbn = 1;
+}
+
+message GetBookViaAuthor {
+  Author author = 1;
+}
+
+message GetBookSeries {
+  int64 isbn = 1;
+}
+
+message BookStore {
+  string name = 1;
+  map<int64, string> books = 2;
+  repeated Genre genres = 3;
+
+  oneof payment_method {
+    int64 credit_card_number = 4;
+    int32 cash = 5;
+    string iou_note = 6;
+    Book barter = 7;
+  }
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -20,12 +20,13 @@ enum BindingType {
 }
 
 message Book {
-  reserved 4, 8;
+  reserved 5, 8;
   reserved 12 to 15;
   int64 isbn = 1;
   string title = 2;
-  repeated Author author = 3;
-  BindingType binding_type = 9;
+  repeated Genre book_genres = 3;
+  repeated Author author = 4;
+  BindingType class = 9;
   Rating rating = 10;
 }
 

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/bookService.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/bookService.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package com.acme;
+
+import "models/author.proto";
+import "book.proto";
+import "rating.proto";
+
+service BookService {
+  rpc GetBook (GetBookRequest) returns (Book);
+  rpc GetBooksViaAuthor (GetBookViaAuthor) returns (stream Book);
+  rpc GetGreatestBook (stream GetBookRequest) returns (Book);
+  rpc GetBooks (stream GetBookRequest) returns (stream Book);
+}
+

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/bookService.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/bookService.proto
@@ -2,12 +2,11 @@ syntax = "proto3";
 
 package com.acme;
 
-import "models/author.proto";
 import "book.proto";
-import "rating.proto";
 
 service BookService {
   rpc GetBook (GetBookRequest) returns (Book);
+  rpc GetBooksSeries (GetBookSeries) returns (Series);
   rpc GetBooksViaAuthor (GetBookViaAuthor) returns (stream Book);
   rpc GetGreatestBook (stream GetBookRequest) returns (Book);
   rpc GetBooks (stream GetBookRequest) returns (stream Book);


### PR DESCRIPTION
This PR shows how protobuf serialization still has failures to be resolved:

**Everything on Proto3 should be optional and we are just generation as optional when using generated messages.**

As Proto2 is also converted to Proto3 we should take some design decisions about this. Also, I cannot find any way to generate an intentional optional with the current design.

**Nested messages classes are not generated. The `BookSeries` model inside the `Series` one is not generated.**

Due to this error, I realized that we are not generating and compiling the scala from the proto we are using. This would help us to detect more bugs in the generation

**Scala keywords are not quoted so scala generated code will not compile**

If we use a scala keyword as the name of a field the generator should quote it using **`** so the generated code can compile