### PR TITLE
Avoid generating invalid Scala identifiers when printing schemas and protocols

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -106,7 +106,7 @@ lazy val commonSettings = Seq(
     %%("cats-effect", V.catsEffect),
     %%("circe-core", V.circe),
     %%("circe-parser", V.circe),
-    "org.scalameta"       %% "scalameta"     % "4.3.0",
+    "org.scalameta"       %% "scalameta"     % V.meta,
     %%("cats-laws", V.cats) % Test,
     "io.circe"            %% "circe-testing" % V.circe % Test,
     %%("scalacheck", V.scalacheck)    % Test,

--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ val V = new {
   val droste           = "0.8.0"
   val kindProjector    = "0.10.3"
   val macroParadise    = "2.1.1"
+  val meta             = "4.3.0"
   val scala212         = "2.12.10"
   val scalacheck       = "1.14.2"
   val specs2           = "4.8.1"
@@ -95,7 +96,6 @@ lazy val commonSettings = Seq(
   crossScalaVersions := Seq(V.scala212),
   ThisBuild / scalacOptions -= "-Xplugin-require:macroparadise",
   libraryDependencies ++= Seq(
-    %%("cats-laws", V.cats) % Test,
     %%("cats-core", V.cats),
     "io.higherkindness"   %% "droste-core"   % V.droste,
     "io.higherkindness"   %% "droste-macros" % V.droste,
@@ -103,10 +103,12 @@ lazy val commonSettings = Seq(
     "com.github.os72"     % "protoc-jar"     % V.protoc,
     "com.google.protobuf" % "protobuf-java"  % V.protobuf,
     "io.circe"            %% "circe-yaml"    % V.circeYaml,
-    "io.circe"            %% "circe-testing" % V.circe % Test,
     %%("cats-effect", V.catsEffect),
     %%("circe-core", V.circe),
     %%("circe-parser", V.circe),
+    "org.scalameta"       %% "scalameta"     % "4.3.0",
+    %%("cats-laws", V.cats) % Test,
+    "io.circe"            %% "circe-testing" % V.circe % Test,
     %%("scalacheck", V.scalacheck)    % Test,
     %%("specs2-core", V.specs2)       % Test,
     "org.typelevel"                   %% "discipline-specs2" % V.disciplineSpecs2 % Test,

--- a/src/main/scala/higherkindness/skeuomorph/Printer.scala
+++ b/src/main/scala/higherkindness/skeuomorph/Printer.scala
@@ -80,6 +80,16 @@ object Printer {
       case xs  => xs.map(p.print).mkString(sep)
     }
 
+  /*
+   * The logic to decide whether a given string needs to be wrapped in backticks
+   * to be a valid Scala identifier is really complicated (the spec is at
+   * https://scala-lang.org/files/archive/spec/2.13/01-lexical-syntax.html#identifiers,
+   * but it's quite wrong/misleading). So we let scalameta take care of it for us.
+   */
+  def toValidIdentifier(string: String): String =
+    if (string.isEmpty) string
+    else scala.meta.Term.Name(string).syntax
+
   implicit val divisiblePrinter: Decidable[Printer] = new Decidable[Printer] {
     def unit: Printer[Unit] = Printer.unit
     def product[A, B](fa: Printer[A], fb: Printer[B]): Printer[(A, B)] = new Printer[(A, B)] {

--- a/src/main/scala/higherkindness/skeuomorph/Printer.scala
+++ b/src/main/scala/higherkindness/skeuomorph/Printer.scala
@@ -58,6 +58,8 @@ object Printer {
 
   val string: Printer[String] = print(identity)
 
+  val identifier: Printer[String] = print(toValidIdentifier)
+
   val unit: Printer[Unit] = print(_ => "")
 
   object avoid {

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -45,7 +45,7 @@ object print {
             openApi)
     }
 
-  val listEnconderPrinter: Printer[Unit] = κ(
+  val listEncoderPrinter: Printer[Unit] = κ(
     "implicit def listEntityEncoder[T: Encoder]: EntityEncoder[F, List[T]] = jsonEncoderOf[F, List[T]]")
   val listDecoderPrinter: Printer[Unit] = κ(
     "implicit def listEntityDecoder[T: Decoder]: EntityDecoder[F, List[T]] = jsonOf[F, List[T]]")
@@ -66,7 +66,7 @@ object print {
         ")") *< κ(": ") *< show[TraitName] >* κ("[F]"),
       κ(" = new ") *< show[TraitName] >* κ("[F] {") >* newLine,
       twoSpaces *< twoSpaces *< sepBy(importDef, "\n") >* newLine *<
-        twoSpaces *< twoSpaces *< listEnconderPrinter *< newLine *<
+        twoSpaces *< twoSpaces *< listEncoderPrinter *< newLine *<
         twoSpaces *< twoSpaces *< listDecoderPrinter *< newLine *<
         twoSpaces *< twoSpaces *< optionListEncoderPrinter *< newLine *<
         twoSpaces *< twoSpaces *< optionListDecoderPrinter *< newLine *<

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -105,7 +105,7 @@ object print {
         val params                     = varPaths ++ queries
         OperationId(
           decapitalize(
-            normalize(operation.operationId
+            ident(operation.operationId
               .getOrElse {
                 val printVerb             = Http.Verb.methodFrom(verb)
                 val printParamsIfRequired = if (params.nonEmpty) s"By${params.mkString}" else ""

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -81,6 +81,18 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
             |}""".stripMargin)
     }
 
+    "when object is provided whose name is a Scala reserved word" >> {
+      schemaWithName
+        .print(
+          "=>" ->
+            Fixed.`object`(List("name" -> Fixed.string()), List("name"))) must ===(
+        s"""|final case class `=>`(name: String)
+            |object `=>` {
+            |
+            |
+            |}""".stripMargin)
+    }
+
     "when object is provided without required fields" >> {
       schemaWithName
         .print(
@@ -103,6 +115,22 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
                 "surname" -> Fixed.string()
               ),
               List("name", "surname"))) must ===(s"""|final case class Person(name: String, surname: String)
+                                                   |object Person {
+                                                   |
+                                                   |
+                                                   |}""".stripMargin)
+    }
+
+    "when object is provided with a field name which is a Scala reserved word" >> {
+      schemaWithName
+        .print(
+          "Person" ->
+            Fixed.`object`(
+              List(
+                "name" -> Fixed.string(),
+                "type" -> Fixed.string()
+              ),
+              List("name", "type"))) must ===(s"""|final case class Person(name: String, `type`: String)
                                                    |object Person {
                                                    |
                                                    |

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -62,15 +62,15 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |}""".stripMargin)
     }
 
-    "when a object type is provided with a not normalize shape" >> {
+    "when a object type is provided with invalid identifier names" >> {
       import client.http4s.circe._
       model.print(
         petstoreOpenApi
           .withSchema("212bar_Foo-X1", obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())) must ===(
         s"""|object models {
             |$modelImports
-            |final case class BarFooX1212(foO1: Option[String], baR: Option[Int])
-            |object BarFooX1212 {
+            |final case class `212bar_Foo-X1`(`1fo_o`: Option[String], `ba-r`: Option[Int])
+            |object `212bar_Foo-X1` {
             |
             |  import io.circe._
             |  import io.circe.generic.semiauto._
@@ -78,11 +78,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |  import org.http4s.circe._
             |  import cats.Applicative
             |  import cats.effect.Sync
-            |  implicit val BarFooX1212Encoder: Encoder[BarFooX1212] = Encoder.forProduct2("1fo_o", "ba-r")(t => (t.foO1, t.baR))
-            |  implicit val BarFooX1212Decoder: Decoder[BarFooX1212] = Decoder.forProduct2("1fo_o", "ba-r")(BarFooX1212.apply)
-            |  implicit def BarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, BarFooX1212] = jsonEncoderOf[F, BarFooX1212]
-            |  implicit def OptionBarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[BarFooX1212]] = jsonEncoderOf[F, Option[BarFooX1212]]
-            |  implicit def BarFooX1212EntityDecoder[F[_]:Sync]: EntityDecoder[F, BarFooX1212] = jsonOf[F, BarFooX1212]
+            |  implicit val BarFooX1212Encoder: Encoder[`212bar_Foo-X1`] = Encoder.forProduct2("1fo_o", "ba-r")(t => (t.`1fo_o`, t.`ba-r`))
+            |  implicit val BarFooX1212Decoder: Decoder[`212bar_Foo-X1`] = Decoder.forProduct2("1fo_o", "ba-r")(`212bar_Foo-X1`.apply)
+            |  implicit def BarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, `212bar_Foo-X1`] = jsonEncoderOf[F, `212bar_Foo-X1`]
+            |  implicit def OptionBarFooX1212EntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[`212bar_Foo-X1`]] = jsonEncoderOf[F, Option[`212bar_Foo-X1`]]
+            |  implicit def BarFooX1212EntityDecoder[F[_]:Sync]: EntityDecoder[F, `212bar_Foo-X1`] = jsonOf[F, `212bar_Foo-X1`]
             |
             |}
             |}""".stripMargin)
@@ -100,7 +100,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
               |}""".stripMargin)
     }
 
-    "when a array type is provided with a not normalize shape" >> {
+    "when a array type is provided with invalid identifier names" >> {
       import Printer.avoid._
       model.print(
         petstoreOpenApi.withSchema(
@@ -108,7 +108,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           Fixed.array(Fixed.reference("#/components/schemas/bar_Foo-X1"))
         )) must ===(s"""|object models {
               |$modelImports
-              |type BarFooX1s = List[BarFooX1]
+              |type `bar_Foo-X1s` = List[`bar_Foo-X1`]
               |}""".stripMargin)
     }
 
@@ -149,16 +149,16 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       )
     }
 
-    "when enum is provided with a not normalize shape" >> {
+    "when enum is provided with invalid identifier names" >> {
       import client.http4s.circe._
       model.print(petstoreOpenApi.withSchema("something-For", Fixed.enum(List("xo-m", "yy-y")))) must ===(
         s"""|object models {
              |$modelImports
-             |sealed trait SomethingFor
-             |object SomethingFor {
+             |sealed trait `something-For`
+             |object `something-For` {
              |
-             |  final case object XoM extends SomethingFor
-             |  final case object YyY extends SomethingFor
+             |  final case object `xo-m` extends `something-For`
+             |  final case object `yy-y` extends `something-For`
              |  import org.http4s.{EntityEncoder, EntityDecoder}
              |  import org.http4s.circe._
              |  import cats.Applicative
@@ -166,20 +166,20 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
              |  import cats._
              |  import cats.implicits._
              |  import io.circe._
-             |  implicit val SomethingForShow: Show[SomethingFor] = Show.show {
-             |  case XoM => "xo-m"
-             |  case YyY => "yy-y"
+             |  implicit val SomethingForShow: Show[`something-For`] = Show.show {
+             |  case `xo-m` => "xo-m"
+             |  case `yy-y` => "yy-y"
              |}
-             |  implicit val SomethingForEncoder: Encoder[SomethingFor] = Encoder.encodeString.contramap(_.show)
-             |  implicit val SomethingForDecoder: Decoder[SomethingFor] = Decoder.decodeString.emap {
-             |  case "xo-m" => XoM.asRight
-             |  case "yy-y" => YyY.asRight
-             |  case x => s"$$x is not valid SomethingFor".asLeft
+             |  implicit val SomethingForEncoder: Encoder[`something-For`] = Encoder.encodeString.contramap(_.show)
+             |  implicit val SomethingForDecoder: Decoder[`something-For`] = Decoder.decodeString.emap {
+             |  case "xo-m" => `xo-m`.asRight
+             |  case "yy-y" => `yy-y`.asRight
+             |  case x => s"$$x is not valid `something-For`".asLeft
              |}
              |
-             |  implicit def SomethingForEntityEncoder[F[_]:Applicative]: EntityEncoder[F, SomethingFor] = jsonEncoderOf[F, SomethingFor]
-             |  implicit def OptionSomethingForEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[SomethingFor]] = jsonEncoderOf[F, Option[SomethingFor]]
-             |  implicit def SomethingForEntityDecoder[F[_]:Sync]: EntityDecoder[F, SomethingFor] = jsonOf[F, SomethingFor]
+             |  implicit def SomethingForEntityEncoder[F[_]:Applicative]: EntityEncoder[F, `something-For`] = jsonEncoderOf[F, `something-For`]
+             |  implicit def OptionSomethingForEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[`something-For`]] = jsonEncoderOf[F, Option[`something-For`]]
+             |  implicit def SomethingForEntityDecoder[F[_]:Sync]: EntityDecoder[F, `something-For`] = jsonOf[F, `something-For`]
              |
              |}
              |}""".stripMargin
@@ -218,6 +218,46 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |  implicit def PetEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Pet] = jsonEncoderOf[F, Pet]
             |  implicit def OptionPetEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Pet]] = jsonEncoderOf[F, Option[Pet]]
             |  implicit def PetEntityDecoder[F[_]:Sync]: EntityDecoder[F, Pet] = jsonOf[F, Pet]
+            |
+            |}
+            |}""".stripMargin)
+
+    }
+
+    "when a sum type is provided with invalid identifier names" >> {
+
+      import client.http4s.circe._
+      model.print(
+        petstoreOpenApi.withSchema(
+          "1-Pet",
+          Fixed.sum(List(
+            Fixed.reference("#/components/schemas/2-Dog"),
+            Fixed.reference("#/components/schemas/3-Cat"))))) must ===(s"""|object models {
+            |$modelImports
+            |import `1-Pet`._
+            |type `1-Pet` = `2-Dog` :+: `3-Cat` :+: CNil
+            |object `1-Pet` {
+            |
+            |  import org.http4s.{EntityEncoder, EntityDecoder}
+            |  import org.http4s.circe._
+            |  import cats.Applicative
+            |  import cats.effect.Sync
+            |  import cats._
+            |  import cats.implicits._
+            |  import io.circe._
+            |  implicit val Pet1Encoder: Encoder[`1-Pet`] = Encoder.instance { x =>
+            |import shapeless.Poly1
+            |object json extends Poly1 {
+            |
+            |implicit def `2-dog` = at[`2-Dog`](x => Encoder[`2-Dog`].apply(x))
+            |implicit def `3-cat` = at[`3-Cat`](x => Encoder[`3-Cat`].apply(x))
+            |}
+            |x.fold(json)
+            |}
+            |  implicit val Pet1Decoder: Decoder[`1-Pet`] = Decoder[`2-Dog`].map(x => Coproduct[`1-Pet`](x)) orElse Decoder[`3-Cat`].map(x => Coproduct[`1-Pet`](x))
+            |  implicit def Pet1EntityEncoder[F[_]:Applicative]: EntityEncoder[F, `1-Pet`] = jsonEncoderOf[F, `1-Pet`]
+            |  implicit def OptionPet1EntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[`1-Pet`]] = jsonEncoderOf[F, Option[`1-Pet`]]
+            |  implicit def Pet1EntityDecoder[F[_]:Sync]: EntityDecoder[F, `1-Pet`] = jsonOf[F, `1-Pet`]
             |
             |}
             |}""".stripMargin)
@@ -311,7 +351,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |}""".stripMargin)
     }
 
-    "when optional body and not optional query parameters is provided" >> {
+    "when optional body and not optional query parameters are provided" >> {
       import client.http4s.circe._
       interfaceDefinition.print(payloadOpenApi.withPath(mediaTypeOptionBody)) must ===(
         """|import models._
@@ -330,7 +370,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       )
     }
 
-    "when parameter are provided as enum" >> {
+    "when parameter is provided as enum" >> {
       import client.http4s.circe._
       interfaceDefinition.print(
         payloadOpenApi.withPath(enumParameterGet)
@@ -339,7 +379,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |import shapeless.{:+:, CNil}
            |trait PayloadClient[F[_]] {
            |  import PayloadClient._
-           |  def getPayload(status: parameters.Status): F[Unit]
+           |  def getPayload(status: parameters.status): F[Unit]
            |}
            |object PayloadClient {
            |
@@ -347,11 +387,11 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |object parameters {
            |
-           |sealed trait Status
-           |object Status {
+           |sealed trait status
+           |object status {
            |
-           |  final case object Pending extends Status
-           |  final case object Active extends Status
+           |  final case object Pending extends status
+           |  final case object Active extends status
            |  import org.http4s.{EntityEncoder, EntityDecoder}
            |  import org.http4s.circe._
            |  import cats.Applicative
@@ -359,20 +399,20 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  import cats._
            |  import cats.implicits._
            |  import io.circe._
-           |  implicit val StatusShow: Show[Status] = Show.show {
+           |  implicit val StatusShow: Show[status] = Show.show {
            |  case Pending => "Pending"
            |  case Active => "Active"
            |}
-           |  implicit val StatusEncoder: Encoder[Status] = Encoder.encodeString.contramap(_.show)
-           |  implicit val StatusDecoder: Decoder[Status] = Decoder.decodeString.emap {
+           |  implicit val StatusEncoder: Encoder[status] = Encoder.encodeString.contramap(_.show)
+           |  implicit val StatusDecoder: Decoder[status] = Decoder.decodeString.emap {
            |  case "Pending" => Pending.asRight
            |  case "Active" => Active.asRight
-           |  case x => s"$x is not valid Status".asLeft
+           |  case x => s"$x is not valid status".asLeft
            |}
            |
-           |  implicit def StatusEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Status] = jsonEncoderOf[F, Status]
-           |  implicit def OptionStatusEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[Status]] = jsonEncoderOf[F, Option[Status]]
-           |  implicit def StatusEntityDecoder[F[_]:Sync]: EntityDecoder[F, Status] = jsonOf[F, Status]
+           |  implicit def StatusEntityEncoder[F[_]:Applicative]: EntityEncoder[F, status] = jsonEncoderOf[F, status]
+           |  implicit def OptionStatusEntityEncoder[F[_]:Applicative]: EntityEncoder[F, Option[status]] = jsonEncoderOf[F, Option[status]]
+           |  implicit def StatusEntityDecoder[F[_]:Sync]: EntityDecoder[F, status] = jsonOf[F, status]
            |
            |}
            |}
@@ -958,7 +998,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       )
     }
 
-    "when params are not normalize" >> {
+    "when params are invalid identifier names" >> {
 
       implDefinition.print(payloadOpenApi.withPath(notNormalizeRequest)) must ===(
         s"""|object PayloadHttpClient {
@@ -966,7 +1006,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PayloadClient[F] = new PayloadClient[F] {
            |    import PayloadClient._
            |$defaultImplicits
-           |    def getId1ById1(id1: String, limitFor: Option[Int], listString: List[String]): F[Unit] = client.expect[Unit](Request[F](method = Method.GET, uri = baseUrl / "1id" / id1.show +?? ("limit-for", limitFor)).with(listString))
+           |    def getId1ById1(`1id`: String, `limit-for`: Option[Int], `List[String]`: List[String]): F[Unit] = client.expect[Unit](Request[F](method = Method.GET, uri = baseUrl / "1id" / `1id`.show +?? ("limit-for", `limit-for`)).with(`List[String]`))
            |  }
            |
            |}""".stripMargin
@@ -1005,7 +1045,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
             |    import PetstoreClient._
             |$defaultImplicits
-            |    def createPayloads(xAuth: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads).withHeaders(Headers.of(Header("X-Auth", xAuth.show), Header("token", token.show)))) {
+            |    def createPayloads(`X-Auth`: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withEntity(newPayloads).withHeaders(Headers.of(Header("X-Auth", `X-Auth`.show), Header("token", token.show)))) {
             |      case Successful(response) => response.as[Unit].map(_.asRight)
             |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
             |    }
@@ -1042,7 +1082,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
         |  def build[F[_]: Effect: Sync](client: Client[F], baseUrl: Uri)($timeQueryParamEncodersImplicit): PetstoreClient[F] = new PetstoreClient[F] {
         |    import PetstoreClient._
         |$defaultImplicits
-        |    def createPayloads(xAuth: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads).withHeaders(Headers(Header("X-Auth", xAuth.show), Header("token", token.show)))) {
+        |    def createPayloads(`X-Auth`: String, token: String, newPayloads: NewPayloads): F[Either[CreatePayloadsErrorResponse, Unit]] = client.fetch[Either[CreatePayloadsErrorResponse, Unit]](Request[F](method = Method.POST, uri = baseUrl / "payloads").withBody(newPayloads).withHeaders(Headers(Header("X-Auth", `X-Auth`.show), Header("token", token.show)))) {
         |      case Successful(response) => response.as[Unit].map(_.asRight)
         |      case default => default.as[Error].map(x => CreatePayloadsUnexpectedErrorResponse(default.status.code, x).asLeft)
         |    }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
@@ -48,7 +48,7 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
         Verb.Put,
         Path("/foo"),
         defaultOperation.withOperationId("create-Payload_V1")
-      ).show must ===("createPayloadV1")
+      ).show must ===("`create-Payload_V1`")
     }
 
     "when the description is not provided and contains special characters" >> {
@@ -80,7 +80,7 @@ class OperationIdSpecification extends org.specs2.mutable.Specification {
         Verb.Put,
         Path("/foo"),
         defaultOperation.withOperationId("1111createPayload")
-      ).show must ===("createPayload1111")
+      ).show must ===("`1111createPayload`")
     }
   }
 }

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -57,7 +57,17 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
         higherkindness.skeuomorph.mu.print.proto.print(p)
     }
 
-    (parseProtocol andThen printProtocol)(protobufProtocol).clean must beEqualTo(expectation(ct, useIdiom).clean)
+    val actual   = (parseProtocol andThen printProtocol)(protobufProtocol)
+    val expected = expectation(ct, useIdiom)
+
+    (actual.clean must beEqualTo(expected.clean)) :| s"""
+      |Actual output:
+      |$actual
+      |
+      |
+      |Expected output:
+      |$expected"
+      """.stripMargin
   }
 
   def expectation(compressionType: CompressionType, useIdiomaticEndpoints: Boolean): String = {
@@ -69,11 +79,13 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     s"""package com.acme
       |
       |import com.acme.author.Author
+      |import com.acme.`hyphenated-name`.Thing
       |import com.acme.rating.Rating
       |
       |object book {
       |
-      |@message final case class Book(isbn: Long, title: String, author: List[Option[Author]], binding_type: Option[BindingType], rating: Option[Rating])
+      |@message final case class Book(isbn: Long, title: String, author: List[Option[Author]], binding_type: Option[BindingType], rating: Option[Rating], `private`: Boolean, `type`: Option[`type`])
+      |@message final case class `type`(foo: Long, thing: Option[Thing])
       |@message final case class GetBookRequest(isbn: Long)
       |@message final case class GetBookViaAuthor(author: Option[Author])
       |@message final case class BookStore(name: String, books: Map[Long, String], genres: List[Option[Genre]], payment_method: Cop[Long :: Int :: String :: Book :: TNil])

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/models/hyphenated-name.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/models/hyphenated-name.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package com.acme;
+
+message Thing {
+    int64 foo = 1;
+}

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package com.acme;
 
 import "models/author.proto";
+import "models/hyphenated-name.proto";
 import "rating.proto";
 
 message Book {
@@ -13,6 +14,13 @@ message Book {
     repeated Author author = 3;
     BindingType binding_type = 9;
     Rating rating = 10;
+    bool private = 11; // note: private is a reserved word in Scala
+    type type = 16; // note: using "type" (a reserved word) as both the field type and field name
+}
+
+message type { // note: type is a reserved word in Scala
+    int64 foo = 1;
+    Thing thing = 2;
 }
 
 message GetBookRequest {


### PR DESCRIPTION
Fixes #114 

Added a new `identifier` combinator to `Printer`, which turns arbitrary strings into valid Scala identifiers by wrapping them with backticks if necessary. Unfortunately it wasn't possible to actually use the combinator in that many places; I ended up directly calling the underlying `Printer.toValidIdentifier` instead.

I didn't want to write my own buggy implementation of the Scala lexical spec, so I used scalameta to take care of the logic to decide when something needs to be backticked.

The printing of Mu schemas/protocols was pretty trivial to fix. The OpenAPI printing, on the other hand, is much more complex. There is a lot more code being generated, and there was already a lot of string manipulation/normalization going on. Because of this, I'm not that confident I've covered every single case correctly, but the test coverage is at least high enough to convince me I haven't made the situation worse.

These changes have caused the OpenAPI codegen behaviour to change in a few cases. Now instead of names being "normalized" (which did not take account of the need to escape Scala reserved words), they are left as-is but wrapped in backticks as necessary when they are used as Scala identifiers. See e.g. [this updated test](https://github.com/higherkindness/skeuomorph/compare/master...cb372:escape-reserved-words?expand=1#diff-199c54d3e60e0f7c8f0c34bd58f7e627R72) for an example of the changes. There were also a couple of small unintended changes that were really hard to avoid without extensive refactoring, e.g. [this change from `Status` to `status`](https://github.com/higherkindness/skeuomorph/compare/master...cb372:escape-reserved-words?expand=1#diff-199c54d3e60e0f7c8f0c34bd58f7e627R390-R391).