### PR TITLE
Use enumeratum IntEnum for generated enums

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
@@ -98,7 +98,7 @@ object Protocol {
     case MuF.TContaining(_)         => ??? // TBD
     case MuF.TRequired(t)           => T.coalgebra(t)
     case MuF.TCoproduct(invariants) => AvroF.union(invariants)
-    case MuF.TSum(name, fields)     => AvroF.enum(name, none[String], Nil, none[String], fields)
+    case MuF.TSum(name, fields)     => AvroF.enum(name, none[String], Nil, none[String], fields.map(_.name))
     case MuF.TProduct(name, fields) =>
       TRecord(
         name,

--- a/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
@@ -47,7 +47,7 @@ object Transform {
     case ProtobufF.TNamedType(prefix, name)         => TNamedType(prefix, name)
     case ProtobufF.TOptionalNamedType(prefix, name) => TOption(A.algebra(TNamedType(prefix, name)))
     case ProtobufF.TRepeated(value)                 => TList(value)
-    case ProtobufF.TEnum(name, symbols, _, _)       => TSum(name, symbols.map(_._1))
+    case ProtobufF.TEnum(name, symbols, _, _)       => TSum(name, symbols.map(SumField.tupled))
     case ProtobufF.TMessage(name, fields, _)        => TProduct(name, fields.map(f => Field(f.name, f.tpe)))
     case ProtobufF.TFileDescriptor(values, _, _)    => TContaining(values)
     case ProtobufF.TOneOf(_, fields)                => TCoproduct(fields.map(_.tpe))
@@ -68,7 +68,7 @@ object Transform {
     case AvroF.TMap(values)     => TMap(None, values)
     case AvroF.TRecord(name, _, _, _, fields) =>
       TProduct(name, fields.map(f => Field(f.name, f.tpe)))
-    case AvroF.TEnum(name, _, _, _, symbols) => TSum(name, symbols)
+    case AvroF.TEnum(name, _, _, _, symbols) => TSum(name, symbols.zipWithIndex.map(SumField.tupled))
     case AvroF.TUnion(options)               => TCoproduct(options)
     case AvroF.TFixed(_, _, _, _) =>
       ??? // I don't really know what to do with Fixed... https://avro.apache.org/docs/current/spec.html#Fixed

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -59,11 +59,13 @@ object print {
       case TCoproduct(invariants) =>
         invariants.toList.mkString("Cop[", " :: ", " :: TNil]")
       case TSum(name, fields) =>
-        val printFields = fields.map(f => s"case object $f extends $name").mkString("\n  ")
+        val printFields = fields.map(f => s"case object ${f.name} extends ${name}(${f.value})").mkString("\n  ")
         s"""
-      |sealed trait $name
-      |object $name {
+      |sealed abstract class $name(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
+      |object $name extends _root_.enumeratum.values.IntEnum[$name] {
       |  $printFields
+      |
+      |  val values = findValues
       |}
       """.stripMargin
       case TProduct(name, fields) =>

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -86,17 +86,21 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |@message final case class GetBookViaAuthor(author: _root_.scala.Option[_root_.com.acme.author.Author])
       |@message final case class BookStore(name: _root_.java.lang.String, books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String], genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]], payment_method: Cop[_root_.scala.Long :: _root_.scala.Int :: _root_.java.lang.String :: _root_.com.acme.book.Book :: TNil])
       |
-      |sealed trait Genre
-      |object Genre {
-      |  case object UNKNOWN extends Genre
-      |  case object SCIENCE_FICTION extends Genre
-      |  case object POETRY extends Genre
+      |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
+      |object Genre extends _root_.enumeratum.values.IntEnum[Genre] {
+      |  case object UNKNOWN extends Genre(0)
+      |  case object SCIENCE_FICTION extends Genre(1)
+      |  case object POETRY extends Genre(2)
+      |
+      |  val values = findValues
       |}
       |
-      |sealed trait BindingType
-      |object BindingType {
-      |  case object HARDCOVER extends BindingType
-      |  case object PAPERBACK extends BindingType
+      |sealed abstract class BindingType(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
+      |object BindingType extends _root_.enumeratum.values.IntEnum[BindingType] {
+      |  case object HARDCOVER extends BindingType(0)
+      |  case object PAPERBACK extends BindingType(5)
+      |
+      |  val values = findValues
       |}
       |
       |@service($serviceParams) trait BookService[F[_]] {

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -63,5 +63,5 @@ enum Genre {
 
 enum BindingType {
     HARDCOVER = 0;
-    PAPERBACK = 1;
+    PAPERBACK = 5;
 }


### PR DESCRIPTION
See https://github.com/47deg/pbdirect/pull/20

Because it is still a plain old sealed abstract class + case object hierarchy, this change will not affect Avro serialization using avro4s (confirmed with manual testing).

Note: This change assumes that enumeratum is on Mu's classpath, which is not yet true. [PR to add it as a dependency](https://github.com/higherkindness/mu/pull/719).

Update: I've tested the whole `.proto` -> src gen -> gRPC server flow manually using locally-published artifacts and confirmed that protobuf enumerations now work 🎉 