### PR TITLE
Add pbIndex annotation to generated Scala code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,8 @@ cache:
   - "$HOME/.sbt"
 
 install:
-  - rvm use 2.6.0 --install --fuzzy
-  - gem update --system
-  - gem install jekyll -v 4.0.0
+  - rvm use 2.6.5 --install --fuzzy
+  - gem install jekyll -v 4
 
 stages:
 - tests

--- a/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
@@ -48,7 +48,7 @@ object Transform {
     case ProtobufF.TOptionalNamedType(prefix, name) => TOption(A.algebra(TNamedType(prefix, name)))
     case ProtobufF.TRepeated(value)                 => TList(value)
     case ProtobufF.TEnum(name, symbols, _, _)       => TSum(name, symbols.map(SumField.tupled))
-    case ProtobufF.TMessage(name, fields, _)        => TProduct(name, fields.map(f => Field(f.name, f.tpe)))
+    case ProtobufF.TMessage(name, fields, _)        => TProduct(name, fields.map(f => Field(f.name, f.tpe, f.indices)))
     case ProtobufF.TFileDescriptor(values, _, _)    => TContaining(values)
     case ProtobufF.TOneOf(_, fields)                => TCoproduct(fields.map(_.tpe))
     case ProtobufF.TMap(key, values)                => TMap(Some(key), values)
@@ -67,7 +67,7 @@ object Transform {
     case AvroF.TArray(item)     => TList(item)
     case AvroF.TMap(values)     => TMap(None, values)
     case AvroF.TRecord(name, _, _, _, fields) =>
-      TProduct(name, fields.map(f => Field(f.name, f.tpe)))
+      TProduct(name, fields.zipWithIndex.map { case (f, i) => Field(f.name, f.tpe, List(i)) })
     case AvroF.TEnum(name, _, _, _, symbols) => TSum(name, symbols.zipWithIndex.map(SumField.tupled))
     case AvroF.TUnion(options)               => TCoproduct(options)
     case AvroF.TFixed(_, _, _, _) =>

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -69,8 +69,12 @@ object print {
       |}
       """.stripMargin
       case TProduct(name, fields) =>
-        val printFields = fields.map(f => s"${toValidIdentifier(f.name)}: ${f.tpe}").mkString(", ")
-        s"@message final case class ${toValidIdentifier(name)}($printFields)"
+        def printField(f: Field[_]) =
+          s"@_root_.pbdirect.pbIndex(${f.indices.mkString(",")}) ${toValidIdentifier(f.name)}: ${f.tpe}"
+        val printFields = fields.map(printField).mkString(",\n  ")
+        s"""|@message final case class ${toValidIdentifier(name)}(
+            |  $printFields
+            |)""".stripMargin
     }
 
     Printer.print(scheme.cata(algebra))

--- a/src/main/scala/higherkindness/skeuomorph/mu/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/schema.scala
@@ -33,7 +33,7 @@ import cats.syntax.eq._
  */
 @deriveTraverse sealed trait MuF[A]
 object MuF {
-  @deriveTraverse final case class Field[A](name: String, tpe: A)
+  @deriveTraverse final case class Field[A](name: String, tpe: A, indices: List[Int])
 
   final case class SumField(name: String, value: Int)
 
@@ -58,7 +58,7 @@ object MuF {
   final case class TProduct[A](name: String, fields: List[Field[A]]) extends MuF[A]
 
   implicit def fieldEq[T](implicit T: Eq[T]): Eq[Field[T]] = Eq.instance {
-    case (Field(n, t), Field(n2, t2)) => n === n2 && t === t2
+    case (Field(n, t, is), Field(n2, t2, is2)) => n === n2 && t === t2 && is === is2
   }
 
   implicit val sumFieldEq: Eq[SumField] = Eq.instance {
@@ -112,7 +112,7 @@ object MuF {
       case TCoproduct(ts)   => ts.toList.mkString("(", " | ", ")")
       case TSum(n, vs)      => vs.map(_.name).mkString(s"$n[", ", ", "]")
       case TProduct(n, fields) =>
-        fields.map(f => s"${f.name}: ${f.tpe}").mkString(s"$n{", ", ", "}")
+        fields.map(f => s"@pbIndex(${f.indices.mkString(",")}) ${f.name}: ${f.tpe}").mkString(s"$n{", ", ", "}")
 
     })
   }

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -268,8 +268,9 @@ object ParseProto {
             .collect { case b @ FieldF.Field(_, _, _, _, _, _) => b })
         .getOrElse(throw ProtobufNativeException(s"Empty set of fields in OneOf: ${oneof.getName}"))
 
-      val fOneOf = oneOf(name = oneof.getName, fields = oneOfFields)
-      (FieldF.OneOfField(name = oneof.getName, tpe = fOneOf.embed), oneOfFields.map(_.position).toList)
+      val fOneOf  = oneOf(name = oneof.getName, fields = oneOfFields)
+      val indices = oneOfFields.map(_.position).toList
+      (FieldF.OneOfField(name = oneof.getName, tpe = fOneOf.embed, indices), indices)
     }
   }
 

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -145,7 +145,8 @@ object instances {
     def fieldGen: Gen[MuF.Field[T]] =
       (
         nonEmptyString,
-        Gen.lzy(T.arbitrary)
+        Gen.lzy(T.arbitrary),
+        Gen.posNum[Int].map(List(_))
       ).mapN(MuF.Field.apply)
 
     Arbitrary(

--- a/src/test/scala/higherkindness/skeuomorph/mu/comparison/ComparisonSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/mu/comparison/ComparisonSpec.scala
@@ -108,36 +108,44 @@ class ComparisonSpec extends Specification {
   }
 
   def fieldAddition = {
-    val original = product("foo", List(Field("name", string[T].embed))).embed
-    val extended = product("foo", List(Field("name", string[T].embed), Field("age", int[T].embed))).embed
+    val original = product("foo", List(Field("name", string[T].embed, List(1)))).embed
+    val extended =
+      product("foo", List(Field("name", string[T].embed, List(1)), Field("age", int[T].embed, List(2)))).embed
 
     Comparison(original, extended) must_== Match(Path.empty / Name("foo") / FieldName("age"), Addition(int[T].embed))
   }
 
   def fieldRemoval = {
-    val original = product("foo", List(Field("name", string[T].embed), Field("age", int[T].embed))).embed
-    val reduced  = product("foo", List(Field("name", string[T].embed))).embed
+    val original =
+      product("foo", List(Field("name", string[T].embed, List(1)), Field("age", int[T].embed, List(2)))).embed
+    val reduced = product("foo", List(Field("name", string[T].embed, List(1)))).embed
 
     Comparison(original, reduced) must_== Match(Path.empty / Name("foo") / FieldName("age"), Removal(int[T].embed))
   }
 
   def optionalPromotion = {
 
-    val original = product("foo", List(Field("name", string[T].embed), Field("age", int[T].embed))).embed
-    val promoted = product("foo", List(Field("name", string[T].embed), Field("age", option(int[T].embed).embed))).embed
+    val original =
+      product("foo", List(Field("name", string[T].embed, List(1)), Field("age", int[T].embed, List(2)))).embed
+    val promoted = product(
+      "foo",
+      List(Field("name", string[T].embed, List(1)), Field("age", option(int[T].embed).embed, List(2)))).embed
 
     Comparison(original, promoted) must_== Match(Path.empty / Name("foo") / FieldName("age"), PromotionToOption[T]())
   }
 
   def eitherPromotion = {
 
-    val original = product("foo", List(Field("name", string[T].embed), Field("age", int[T].embed))).embed
+    val original =
+      product("foo", List(Field("name", string[T].embed, List(1)), Field("age", int[T].embed, List(2)))).embed
     val promotedL = product(
       "foo",
-      List(Field("name", string[T].embed), Field("age", either(int[T].embed, boolean[T].embed).embed))).embed
+      List(
+        Field("name", string[T].embed, List(1)),
+        Field("age", either(int[T].embed, boolean[T].embed).embed, List(2)))).embed
     val promotedR = product(
       "foo",
-      List(Field("name", either(long[T].embed, string[T].embed).embed), Field("age", int[T].embed))).embed
+      List(Field("name", either(long[T].embed, string[T].embed).embed, List(1)), Field("age", int[T].embed, List(2)))).embed
 
     Comparison(original, promotedL) must_== Match(
       Path.empty / Name("foo") / FieldName("age"),

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -80,11 +80,31 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |
       |object book {
       |
-      |@message final case class Book(isbn: _root_.scala.Long, title: _root_.java.lang.String, author: _root_.scala.List[_root_.scala.Option[_root_.com.acme.author.Author]], binding_type: _root_.scala.Option[_root_.com.acme.book.BindingType], rating: _root_.scala.Option[_root_.com.acme.rating.Rating], `private`: _root_.scala.Boolean, `type`: _root_.scala.Option[_root_.com.acme.book.`type`])
-      |@message final case class `type`(foo: _root_.scala.Long, thing: _root_.scala.Option[_root_.com.acme.`hyphenated-name`.Thing])
-      |@message final case class GetBookRequest(isbn: _root_.scala.Long)
-      |@message final case class GetBookViaAuthor(author: _root_.scala.Option[_root_.com.acme.author.Author])
-      |@message final case class BookStore(name: _root_.java.lang.String, books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String], genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]], payment_method: Cop[_root_.scala.Long :: _root_.scala.Int :: _root_.java.lang.String :: _root_.com.acme.book.Book :: TNil])
+      |@message final case class Book(
+      |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long,
+      |  @_root_.pbdirect.pbIndex(2) title: _root_.java.lang.String,
+      |  @_root_.pbdirect.pbIndex(3) author: _root_.scala.List[_root_.scala.Option[_root_.com.acme.author.Author]],
+      |  @_root_.pbdirect.pbIndex(9) binding_type: _root_.scala.Option[_root_.com.acme.book.BindingType],
+      |  @_root_.pbdirect.pbIndex(10) rating: _root_.scala.Option[_root_.com.acme.rating.Rating],
+      |  @_root_.pbdirect.pbIndex(11) `private`: _root_.scala.Boolean,
+      |  @_root_.pbdirect.pbIndex(16) `type`: _root_.scala.Option[_root_.com.acme.book.`type`]
+      |)
+      |@message final case class `type`(
+      |  @_root_.pbdirect.pbIndex(1) foo: _root_.scala.Long,
+      |  @_root_.pbdirect.pbIndex(2) thing: _root_.scala.Option[_root_.com.acme.`hyphenated-name`.Thing]
+      |)
+      |@message final case class GetBookRequest(
+      |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long
+      |)
+      |@message final case class GetBookViaAuthor(
+      |  @_root_.pbdirect.pbIndex(1) author: _root_.scala.Option[_root_.com.acme.author.Author]
+      |)
+      |@message final case class BookStore(
+      |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
+      |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String],
+      |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]],
+      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: Cop[_root_.scala.Long :: _root_.scala.Int :: _root_.java.lang.String :: _root_.com.acme.book.Book :: TNil]
+      |)
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
       |object Genre extends _root_.enumeratum.values.IntEnum[Genre] {


### PR DESCRIPTION
See https://github.com/47deg/pbdirect/pull/21

If a Mu user chooses Protobuf for the serialization of messages, the pbdirect library will make use of these annotations to discover the correct index number of each field.

In the case of Avro serialization, the annotation will simply be ignored by avro4s.

Also tidied up the generated code slightly by putting each field on a separate line.