### PR TITLE
Generate a shapeless Coproduct instead of a placeholder type

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -57,7 +57,7 @@ object print {
       case TContaining(values)       => values.mkString("\n")
       case TRequired(value)          => value
       case TCoproduct(invariants) =>
-        invariants.toList.mkString("Cop[", " :: ", " :: TNil]")
+        invariants.toList.mkString("", " :+: ", " :+: CNil")
       case TSum(name, fields) =>
         val printFields = fields.map(f => s"case object ${f.name} extends ${name}(${f.value})").mkString("\n  ")
         s"""

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -57,7 +57,7 @@ object print {
       case TContaining(values)       => values.mkString("\n")
       case TRequired(value)          => value
       case TCoproduct(invariants) =>
-        invariants.toList.mkString("", " :+: ", " :+: CNil")
+        invariants.toList.mkString("", " _root_.shapeless.:+: ", " :+: _root_.shapeless.CNil")
       case TSum(name, fields) =>
         val printFields = fields.map(f => s"case object ${f.name} extends ${name}(${f.value})").mkString("\n  ")
         s"""

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -103,7 +103,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]],
-      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: Cop[_root_.scala.Long :: _root_.scala.Int :: _root_.java.lang.String :: _root_.com.acme.book.Book :: TNil]
+      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Long :+: _root_.scala.Int :+: _root_.java.lang.String :+: _root_.com.acme.book.Book :+: CNil
       |)
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -103,7 +103,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]],
-      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Long :+: _root_.scala.Int :+: _root_.java.lang.String :+: _root_.com.acme.book.Book :+: CNil
+      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Long _root_.shapeless.:+: _root_.scala.Int _root_.shapeless.:+: _root_.java.lang.String _root_.shapeless.:+: _root_.com.acme.book.Book :+: _root_.shapeless.CNil
       |)
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry


### PR DESCRIPTION
Previously we were generating a made-up type `Cop[A :: B :: TNil]`. There is [code in the Mu sbt plugin](https://github.com/higherkindness/mu-scala/blob/0dab66791fef6caf7123df613213ba351475049a/modules/idlgen/core/src/main/scala/higherkindness/mu/rpc/idlgen/proto/ProtoSrcGenerator.scala#L65-L71) to rewrite it to `A :+: B :+: CNil` using some regex nastiness. We may as well generate a real type in the first place and remove the need for rewriting.