### PR TITLE
Wrap coproducts in Option

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/FileUtils.scala
+++ b/src/main/scala/higherkindness/skeuomorph/FileUtils.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/Parser.scala
+++ b/src/main/scala/higherkindness/skeuomorph/Parser.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/Printer.scala
+++ b/src/main/scala/higherkindness/skeuomorph/Printer.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/SkeuomorphError.scala
+++ b/src/main/scala/higherkindness/skeuomorph/SkeuomorphError.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/avro/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/schema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/catz/contrib/ContravariantMonoidalSyntax.scala
+++ b/src/main/scala/higherkindness/skeuomorph/catz/contrib/ContravariantMonoidalSyntax.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/catz/contrib/Decidable.scala
+++ b/src/main/scala/higherkindness/skeuomorph/catz/contrib/Decidable.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/Optimize.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Optimize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
@@ -50,7 +50,7 @@ object Transform {
     case ProtobufF.TEnum(name, symbols, _, _)       => TSum(name, symbols.map(SumField.tupled))
     case ProtobufF.TMessage(name, fields, _)        => TProduct(name, fields.map(f => Field(f.name, f.tpe, f.indices)))
     case ProtobufF.TFileDescriptor(values, _, _)    => TContaining(values)
-    case ProtobufF.TOneOf(_, fields)                => TCoproduct(fields.map(_.tpe))
+    case ProtobufF.TOneOf(_, fields)                => TOption(A.algebra(TCoproduct(fields.map(_.tpe))))
     case ProtobufF.TMap(key, values)                => TMap(Some(key), values)
   }
 

--- a/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Comparison.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Comparison.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Path.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Path.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Transformation.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Transformation.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -57,7 +57,7 @@ object print {
       case TContaining(values)       => values.mkString("\n")
       case TRequired(value)          => value
       case TCoproduct(invariants) =>
-        invariants.toList.mkString("_root_.scala.Option[", " _root_.shapeless.:+: ", " :+: _root_.shapeless.CNil]")
+        invariants.toList.mkString("", " _root_.shapeless.:+: ", " :+: _root_.shapeless.CNil")
       case TSum(name, fields) =>
         val printFields = fields.map(f => s"case object ${f.name} extends ${name}(${f.value})").mkString("\n  ")
         s"""

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -57,7 +57,7 @@ object print {
       case TContaining(values)       => values.mkString("\n")
       case TRequired(value)          => value
       case TCoproduct(invariants) =>
-        invariants.toList.mkString("", " _root_.shapeless.:+: ", " :+: _root_.shapeless.CNil")
+        invariants.toList.mkString("_root_.scala.Option[", " _root_.shapeless.:+: ", " :+: _root_.shapeless.CNil]")
       case TSum(name, fields) =>
         val printFields = fields.map(f => s"case object ${f.name} extends ${name}(${f.value})").mkString("\n  ")
         s"""

--- a/src/main/scala/higherkindness/skeuomorph/mu/protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/protocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/mu/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/schema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonSchema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonSchema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/Optimize.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/Optimize.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/ParseOpenApi.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/ParseOpenApi.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/print.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/print.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/schema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/openapi/yaml.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/yaml.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -197,7 +197,7 @@ object ParseProto {
         FieldF.Field(
           name = field.getName,
           position = field.getNumber,
-          tpe = repeated[A](fromFieldType(field, files, makeNamedTypesOptional = true)).embed,
+          tpe = repeated[A](fromFieldType(field, files, makeNamedTypesOptional = false)).embed,
           options = fromFieldOptionsMsg(field.getOptions),
           isRepeated = true,
           isMapField = false

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/Protocol.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/print.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/PrinterSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/PrinterSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/avro/AvroSchemaSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/avro/AvroSchemaSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/avro/AvroSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/avro/AvroSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/mu/MuSchemaSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/mu/MuSchemaSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/mu/OptimizeSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/mu/OptimizeSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/mu/comparison/ComparisonSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/mu/comparison/ComparisonSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaDecoderSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiSchemaSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiSchemaSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OperationIdSpecification.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtoSchemaSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtoSchemaSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -103,7 +103,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]],
-      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Long _root_.shapeless.:+: _root_.scala.Int _root_.shapeless.:+: _root_.java.lang.String _root_.shapeless.:+: _root_.com.acme.book.Book :+: _root_.shapeless.CNil
+      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.scala.Long _root_.shapeless.:+: _root_.scala.Int _root_.shapeless.:+: _root_.java.lang.String _root_.shapeless.:+: _root_.com.acme.book.Book :+: _root_.shapeless.CNil]
       |)
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2019 47 Degrees, LLC. <http://www.47deg.com>
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -83,7 +83,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |@message final case class Book(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) title: _root_.java.lang.String,
-      |  @_root_.pbdirect.pbIndex(3) author: _root_.scala.List[_root_.scala.Option[_root_.com.acme.author.Author]],
+      |  @_root_.pbdirect.pbIndex(3) author: _root_.scala.List[_root_.com.acme.author.Author],
       |  @_root_.pbdirect.pbIndex(9) binding_type: _root_.scala.Option[_root_.com.acme.book.BindingType],
       |  @_root_.pbdirect.pbIndex(10) rating: _root_.scala.Option[_root_.com.acme.rating.Rating],
       |  @_root_.pbdirect.pbIndex(11) `private`: _root_.scala.Boolean,
@@ -102,7 +102,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |@message final case class BookStore(
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String],
-      |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.scala.Option[_root_.com.acme.book.Genre]],
+      |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
       |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.scala.Long _root_.shapeless.:+: _root_.scala.Int _root_.shapeless.:+: _root_.java.lang.String _root_.shapeless.:+: _root_.com.acme.book.Book :+: _root_.shapeless.CNil]
       |)
       |


### PR DESCRIPTION
This is so they can be encoded as `oneof` fields in protobuf using pbdirect (see https://github.com/47deg/pbdirect/pull/30).

Also stop wrapping repeated field elements in Option when parsing protobuf protocols.