### PR TITLE
Fix a couple of compilation issues in the generated code

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -50,8 +50,8 @@ object print {
       case TNamedType(prefix, name)  => printIdentifier(prefix, name)
       case TOption(value)            => s"_root_.scala.Option[$value]"
       case TEither(a, b)             => s"_root_.scala.Either[$a, $b]"
-      case TMap(Some(key), value)    => s"_root_.scala.Map[$key, $value]"
-      case TMap(None, value)         => s"_root_.scala.Map[String, $value]" // Compatibility for Avro
+      case TMap(Some(key), value)    => s"_root_.scala.Predef.Map[$key, $value]"
+      case TMap(None, value)         => s"_root_.scala.Predef.Map[String, $value]" // Compatibility for Avro
       case TGeneric(generic, params) => s"""$generic[${params.mkString(", ")}]"""
       case TList(value)              => s"_root_.scala.List[$value]"
       case TContaining(values)       => values.mkString("\n")

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -57,7 +57,7 @@ object print {
       case TContaining(values)       => values.mkString("\n")
       case TRequired(value)          => value
       case TCoproduct(invariants) =>
-        invariants.toList.mkString("", " _root_.shapeless.:+: ", " :+: _root_.shapeless.CNil")
+        invariants.toList.foldRight("_root_.shapeless.CNil") { case (t, acc) => s"_root_.shapeless.:+:[$t, $acc]" }
       case TSum(name, fields) =>
         val printFields = fields.map(f => s"case object ${f.name} extends ${name}(${f.value})").mkString("\n  ")
         s"""

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -101,9 +101,9 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |)
       |@message final case class BookStore(
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
-      |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Map[_root_.scala.Long, _root_.java.lang.String],
+      |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Predef.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
-      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.scala.Long _root_.shapeless.:+: _root_.scala.Int _root_.shapeless.:+: _root_.java.lang.String _root_.shapeless.:+: _root_.com.acme.book.Book :+: _root_.shapeless.CNil]
+      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.shapeless.:+:[_root_.scala.Long, _root_.shapeless.:+:[_root_.scala.Int, _root_.shapeless.:+:[_root_.java.lang.String, _root_.shapeless.:+:[_root_.com.acme.book.Book, _root_.shapeless.CNil]]]]]
       |)
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry


### PR DESCRIPTION
* `scala.Map` should be `scala.Predef.Map`
* Can't write shapeless coproduct types using infix notation.

The compiler isn't happy with using a qualified type (e.g. `_root_.shapeless.:+:`) in infix position.

Updated to write the type as e.g. `_root_.shapeless.:+:[Int, _root_.shapeless.:+:[String, _root_.shapeless.CNil]]`. It's not pretty, but it compiles.