### PR TITLE
Use scalameta for codegen

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,6 +19,7 @@ val V = new {
   val kindProjector    = "0.10.3"
   val macroParadise    = "2.1.1"
   val meta             = "4.3.0"
+  val metaContrib      = "4.1.6"
   val scala212         = "2.12.10"
   val scalacheck       = "1.14.3"
   val specs2           = "4.8.1"
@@ -122,7 +123,8 @@ lazy val commonSettings = Seq(
     "org.typelevel"                   %% "discipline-specs2" % V.disciplineSpecs2 % Test,
     %%("specs2-scalacheck", V.specs2) % Test,
     "io.chrisdavenport"               %% "cats-scalacheck" % V.catsScalacheck % Test excludeAll (
-      ExclusionRule(organization = "org.scalacheck")
+      ExclusionRule(organization = "org.scalacheck"),
+    "org.scalameta"       %% "contrib"     % V.metaContrib % Test
     )
   ),
   orgProjectName := "Skeuomorph",

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -95,8 +95,8 @@ val avroSchema: Schema = new Schema.Parser().parse(definition)
 val toMuSchema: Schema => Mu[MuF] =
   scheme.hylo(transformAvro[Mu[MuF]].algebra, fromAvro)
 
-val printSchemaAsScala: Mu[MuF] => String =
-  codegen.schema(_).right.get.syntax
+val printSchemaAsScala: Mu[MuF] => Either[String, String] =
+  codegen.schema(_).map(_.syntax)
 
 (toMuSchema >>> println)(avroSchema)
 println("=====")
@@ -152,11 +152,11 @@ val toMuProtocol: Protocol[Mu[ProtobufF]] => mu.Protocol[Mu[MuF]] = { p: Protoco
   mu.Protocol.fromProtobufProto(CompressionType.Identity, true)(p)
 }
 
-val printProtocolAsScala: mu.Protocol[Mu[MuF]] => String = { p =>
+val printProtocolAsScala: mu.Protocol[Mu[MuF]] => Either[String, String] = { p =>
   val streamCtor: (Type, Type) => Type.Apply = {
     case (f, a) => t"_root_.fs2.Stream[$f, $a]"
   }
-  mu.codegen.protocol(p, streamCtor).right.get.syntax
+  mu.codegen.protocol(p, streamCtor).map(_.syntax)
 }
 
 (toMuProtocol >>> println)(protobufProtocol)

--- a/docs/docs/docs/index.md
+++ b/docs/docs/docs/index.md
@@ -42,7 +42,7 @@ libraryDependencies += "io.higherkindness" %% "skeuomorph" % "0.0.19"
 
 ## Examples
 
-### parsing an avro schema and then converting it to scala:
+### Parsing an Avro schema and converting it into Scala code
 
 Given an Avro schema:
 
@@ -76,18 +76,19 @@ val definition = """
 """
 ```
 
-We can parse and convert it into Scala code like this:
+We can parse it, transform it into a Mu schema and then convert it into Scala code like this:
 
 ```scala mdoc:silent
 import org.apache.avro.{Protocol => AvroProtocol, _}
 import higherkindness.skeuomorph.mu.Transform.transformAvro
 import higherkindness.skeuomorph.mu.MuF
-import higherkindness.skeuomorph.mu.{print => muprint}
+import higherkindness.skeuomorph.mu.codegen
 import higherkindness.skeuomorph.avro.AvroF.fromAvro
 import higherkindness.droste._
 import higherkindness.droste.data._
 import higherkindness.droste.data.Mu._
 import cats.implicits._
+import scala.meta._
 
 val avroSchema: Schema = new Schema.Parser().parse(definition)
 
@@ -95,7 +96,7 @@ val toMuSchema: Schema => Mu[MuF] =
   scheme.hylo(transformAvro[Mu[MuF]].algebra, fromAvro)
 
 val printSchemaAsScala: Mu[MuF] => String =
-  muprint.schema.print _
+  codegen.schema(_).right.get.syntax
 
 (toMuSchema >>> println)(avroSchema)
 println("=====")
@@ -114,7 +115,7 @@ println("```")
 
 ## Protobuf
 
-### Parsing `.proto` file and converting into Scala code
+### Parsing a `.proto` file and converting into Scala code
 
 Given the proto file below:
 
@@ -131,7 +132,7 @@ message User {
 }
 ```
 
-We can parse and convert it into Scala code as:
+We can parse it, transform it into a Mu protocol and then convert it into Scala code like this:
 
 ```scala mdoc:silent
 import cats.effect.IO
@@ -141,6 +142,7 @@ import higherkindness.skeuomorph.protobuf._
 import higherkindness.droste.data.Mu
 import higherkindness.droste.data.Mu._
 import cats.implicits._
+import scala.meta._
 
 val source = ParseProto.ProtoSource("user.proto", new java.io.File(".").getAbsolutePath ++ "/docs/protobuf")
 
@@ -150,8 +152,12 @@ val toMuProtocol: Protocol[Mu[ProtobufF]] => mu.Protocol[Mu[MuF]] = { p: Protoco
   mu.Protocol.fromProtobufProto(CompressionType.Identity, true)(p)
 }
 
-val printProtocolAsScala: mu.Protocol[Mu[MuF]] => String =
-  mu.print.proto.print _
+val printProtocolAsScala: mu.Protocol[Mu[MuF]] => String = { p =>
+  val streamCtor: (Type, Type) => Type.Apply = {
+    case (f, a) => t"_root_.fs2.Stream[$f, $a]"
+  }
+  mu.codegen.protocol(p, streamCtor).right.get.syntax
+}
 
 (toMuProtocol >>> println)(protobufProtocol)
 println("=====")

--- a/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2018-2020 47 Degrees, LLC. <http://www.47deg.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package higherkindness.skeuomorph.mu
+
+import scala.meta._
+import scala.meta.classifiers.Classifier
+import scala.meta.Term.Block
+import higherkindness.droste._
+import higherkindness.skeuomorph.mu.MuF._
+import higherkindness.skeuomorph.mu.Optimize._
+import scala.reflect.ClassTag
+
+object codegen {
+
+  private implicit class TreeHack(val tree: Tree) extends AnyVal {
+    def as[A](implicit tag: ClassTag[A], classifier: Classifier[Tree, A]): A = {
+      require(tree.is[A], s"Expected a tree of type ${tag.runtimeClass.getName} but got: $tree (${tree.structure})")
+      tree.asInstanceOf[A]
+    }
+  }
+
+  def optimize[T](t: T)(implicit T: Basis[MuF, T]): T =
+    // Apply optimizations to normalise the protocol
+    // before converting it to Scala code
+    (nestedOptionInCoproduct[T] andThen knownCoproductTypes[T]).apply(t)
+
+  def protocol[T](
+      protocol: Protocol[T],
+      streamCtor: (Type, Type) => Type.Apply
+  )(implicit T: Basis[MuF, T]): Pkg = {
+    val packageName = protocol.pkg.getOrElse("proto")
+    val packageTerm = packageName.parse[Term].get.as[Term.Ref]
+
+    val objDefn = q"""
+    // TODO options (Where should these annotations be attached to? And what are they for?)
+    // TODO dependency imports
+    object ${Term.Name(protocol.name)} {
+      ..${protocol.declarations.flatMap(t => explodeBlock(schema(optimize(t)).as[Stat]))}
+      ..${protocol.services.map(s => service(s, streamCtor))}
+    }
+    """
+    Pkg(packageTerm, List(objDefn))
+  }
+
+  // A class and its companion object will be wrapped inside a Block (i.e. curly braces).
+  // We need to extract them from there and lift them to the same level as other statements.
+  private def explodeBlock(stat: Stat): List[Stat] = stat match {
+    case Block(stats) => stats
+    case other        => List(other)
+  }
+
+  def schema[T](decl: T)(implicit T: Basis[MuF, T]): Tree = {
+
+    def identifier(prefix: List[String], name: String): Type = {
+      if (prefix.isEmpty)
+        Type.Name(name)
+      else {
+        val path     = prefix.map(Term.Name(_))
+        val pathTerm = path.foldLeft[Term](Term.Name("_root_")) { case (acc, name) => Term.Select(acc, name) }
+        Type.Select(pathTerm.as[Term.Ref], Type.Name(name))
+      }
+    }
+
+    // TODO This works but we lose a lot of type information because everything becomes a Tree.
+    // We have to do a lot of casting as a result. Is there a better way to do this?
+    val algebra: Algebra[MuF, Tree] = Algebra {
+      case TNull()                  => t"Null"
+      case TDouble()                => t"_root_.scala.Double"
+      case TFloat()                 => t"_root_.scala.Float"
+      case TInt()                   => t"_root_.scala.Int"
+      case TLong()                  => t"_root_.scala.Long"
+      case TBoolean()               => t"_root_.scala.Boolean"
+      case TString()                => t"_root_.java.lang.String"
+      case TByteArray()             => t"_root_.scala.Array[Byte]"
+      case TNamedType(prefix, name) => identifier(prefix, name)
+      case TOption(value)           => t"_root_.scala.Option[${value.as[Type]}]"
+      case TEither(a, b)            => t"_root_.scala.Either[${a.as[Type]}, ${b.as[Type]}]"
+      case TMap(Some(key), value)   => t"_root_.scala.Predef.Map[${key.as[Type]}, ${value.as[Type]}]"
+      case TMap(None, value) =>
+        t"_root_.scala.Predef.Map[_root_.java.lang.String, ${value.as[Type]}]" // Compatibility for Avro
+      case TGeneric(generic, tparams) => t"${generic.as[Type]}[..${tparams.map(_.as[Type])}]"
+      case TList(value)               => t"_root_.scala.List[${value.as[Type]}]"
+      case TContaining(values)        => q"..${values.map(_.as[Stat])}"
+      case TRequired(value)           => value
+      case TCoproduct(invariants) =>
+        invariants.toList.foldRight[Type](t"_root_.shapeless.CNil") {
+          case (t, acc) => t"_root_.shapeless.:+:[${t.as[Type]}, ${acc.as[Type]}]"
+        }
+      case TSum(name, fields) =>
+        val typeName   = Type.Name(name)
+        val fieldDefns = fields.map(f => q"case object ${Term.Name(f.name)} extends $typeName(${f.value})")
+        q"""
+        sealed abstract class $typeName(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
+        object ${Term.Name(name)} extends _root_.enumeratum.values.IntEnum[$typeName] {
+          ..$fieldDefns
+
+          ;
+          val values = findValues
+        }
+        """
+      case TProduct(name, fields) =>
+        def arg(f: Field[_]) = {
+          val annotation = mod"@_root_.pbdirect.pbIndex(..${f.indices.map(Lit.Int(_))})"
+          param"$annotation ${Term.Name(f.name)}: ${Some(f.tpe.asInstanceOf[Type])}"
+        }
+        val args = fields.map(arg)
+        q"@message final case class ${Type.Name(name)}(..$args)"
+    }
+
+    scheme.cata(algebra).apply(decl)
+  }
+
+  def service[T](srv: Service[T], streamCtor: (Type, Type) => Type.Apply)(implicit T: Basis[MuF, T]): Stat = {
+    val serializationType = Term.Name(srv.serializationType.toString)
+    val compressionType   = Term.Name(srv.compressionType.toString)
+
+    val serviceAnnotation = srv.idiomaticEndpoints match {
+      case IdiomaticEndpoints(Some(pkg), true) =>
+        mod"@service($serializationType, $compressionType, namespace = Some($pkg), methodNameStyle = Capitalize)"
+      case IdiomaticEndpoints(None, true) =>
+        mod"@service($serializationType, $compressionType, methodNameStyle = Capitalize)"
+      case _ =>
+        mod"@service($serializationType, $compressionType)"
+    }
+
+    q"""
+    @$serviceAnnotation trait ${Type.Name(srv.name)}[F[_]] {
+      ..${srv.operations.map(op => operation(op, streamCtor))}
+    }
+    """
+  }
+
+  def operation[T](op: Service.Operation[T], streamCtor: (Type, Type) => Type.Apply)(
+      implicit T: Basis[MuF, T]): Decl.Def =
+    q"def ${Term.Name(op.name)}(req: ${requestType(op.request, streamCtor)}): ${responseType(op.response, streamCtor)}"
+
+  def requestType[T](opType: Service.OperationType[T], streamCtor: (Type, Type) => Type.Apply)(
+      implicit T: Basis[MuF, T]): Type = {
+    val tpe = schema(opType.tpe).as[Type]
+
+    if (opType.stream)
+      streamCtor(Type.Name("F"), tpe)
+    else
+      tpe
+  }
+
+  def responseType[T](opType: Service.OperationType[T], streamCtor: (Type, Type) => Type.Apply)(
+      implicit T: Basis[MuF, T]): Type.Apply = {
+    val tpe = schema(opType.tpe).as[Type]
+
+    if (opType.stream)
+      streamCtor(Type.Name("F"), tpe)
+    else
+      t"F[$tpe]"
+  }
+}

--- a/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
@@ -23,38 +23,68 @@ import higherkindness.droste._
 import higherkindness.skeuomorph.mu.MuF._
 import higherkindness.skeuomorph.mu.Optimize._
 import scala.reflect.ClassTag
+import cats.syntax.either._
+import cats.syntax.traverse._
+import cats.instances.either._
+import cats.instances.list._
+import cats.syntax.apply._
 
 object codegen {
 
-  private implicit class TreeHack(val tree: Tree) extends AnyVal {
-    def as[A](implicit tag: ClassTag[A], classifier: Classifier[Tree, A]): A = {
-      require(tree.is[A], s"Expected a tree of type ${tag.runtimeClass.getName} but got: $tree (${tree.structure})")
-      tree.asInstanceOf[A]
-    }
+  private implicit class TreeSyntax(val tree: Tree) extends AnyVal {
+    def as[A](implicit tag: ClassTag[A], classifier: Classifier[Tree, A]): Either[String, A] =
+      Either.cond(
+        tree.is[A],
+        tree.asInstanceOf[A],
+        s"Expected a tree of type ${tag.runtimeClass.getName} but got: $tree (${tree.structure})"
+      )
   }
-
-  def optimize[T](t: T)(implicit T: Basis[MuF, T]): T =
-    // Apply optimizations to normalise the protocol
-    // before converting it to Scala code
-    (nestedOptionInCoproduct[T] andThen knownCoproductTypes[T]).apply(t)
 
   def protocol[T](
       protocol: Protocol[T],
       streamCtor: (Type, Type) => Type.Apply
-  )(implicit T: Basis[MuF, T]): Pkg = {
-    val packageName = protocol.pkg.getOrElse("proto")
-    val packageTerm = packageName.parse[Term].get.as[Term.Ref]
+  )(implicit T: Basis[MuF, T]): Either[String, Pkg] = {
 
-    val objDefn = q"""
-    // TODO options (Where should these annotations be attached to? And what are they for?)
-    // TODO dependency imports
-    object ${Term.Name(protocol.name)} {
-      ..${protocol.declarations.flatMap(t => explodeBlock(schema(optimize(t)).as[Stat]))}
-      ..${protocol.services.map(s => service(s, streamCtor))}
+    val packageName = protocol.pkg
+      .getOrElse("proto")
+      .parse[Term]
+      .toEither
+      .leftMap(e => s"Failed to parse package name: $e")
+      .flatMap(_.as[Term.Ref])
+
+    def declaration(decl: T): Either[String, List[Stat]] =
+      for {
+        tree <- schema(optimize(decl))
+        stat <- tree.as[Stat]
+      } yield explodeBlock(stat)
+
+    val declarations: Either[String, List[Stat]] =
+      protocol.declarations.flatTraverse(declaration)
+
+    val services: Either[String, List[Stat]] =
+      protocol.services.traverse(s => service(s, streamCtor))
+
+    for {
+      pkgName <- packageName
+      decls   <- declarations
+      srvs    <- services
+    } yield {
+      val objDefn = q"""
+      // TODO options (Where should these annotations be attached to? And what are they for?)
+      // TODO dependency imports
+      object ${Term.Name(protocol.name)} {
+        ..$decls
+        ..$srvs
+      }
+      """
+      Pkg(pkgName, List(objDefn))
     }
-    """
-    Pkg(packageTerm, List(objDefn))
   }
+
+  private def optimize[T](t: T)(implicit T: Basis[MuF, T]): T =
+    // Apply optimizations to normalise the protocol
+    // before converting it to Scala code
+    (nestedOptionInCoproduct[T] andThen knownCoproductTypes[T]).apply(t)
 
   // A class and its companion object will be wrapped inside a Block (i.e. curly braces).
   // We need to extract them from there and lift them to the same level as other statements.
@@ -63,42 +93,52 @@ object codegen {
     case other        => List(other)
   }
 
-  def schema[T](decl: T)(implicit T: Basis[MuF, T]): Tree = {
+  def schema[T](decl: T)(implicit T: Basis[MuF, T]): Either[String, Tree] = {
 
-    def identifier(prefix: List[String], name: String): Type = {
+    def identifier(prefix: List[String], name: String): Either[String, Type] = {
       if (prefix.isEmpty)
-        Type.Name(name)
+        Type.Name(name).asRight
       else {
         val path     = prefix.map(Term.Name(_))
         val pathTerm = path.foldLeft[Term](Term.Name("_root_")) { case (acc, name) => Term.Select(acc, name) }
-        Type.Select(pathTerm.as[Term.Ref], Type.Name(name))
+        pathTerm.as[Term.Ref].map(p => Type.Select(p, Type.Name(name)))
       }
     }
 
-    // TODO This works but we lose a lot of type information because everything becomes a Tree.
-    // We have to do a lot of casting as a result. Is there a better way to do this?
-    val algebra: Algebra[MuF, Tree] = Algebra {
-      case TNull()                  => t"Null"
-      case TDouble()                => t"_root_.scala.Double"
-      case TFloat()                 => t"_root_.scala.Float"
-      case TInt()                   => t"_root_.scala.Int"
-      case TLong()                  => t"_root_.scala.Long"
-      case TBoolean()               => t"_root_.scala.Boolean"
-      case TString()                => t"_root_.java.lang.String"
-      case TByteArray()             => t"_root_.scala.Array[Byte]"
+    val algebra: AlgebraM[Either[String, ?], MuF, Tree] = AlgebraM {
+      case TNull()                  => t"Null".asRight
+      case TDouble()                => t"_root_.scala.Double".asRight
+      case TFloat()                 => t"_root_.scala.Float".asRight
+      case TInt()                   => t"_root_.scala.Int".asRight
+      case TLong()                  => t"_root_.scala.Long".asRight
+      case TBoolean()               => t"_root_.scala.Boolean".asRight
+      case TString()                => t"_root_.java.lang.String".asRight
+      case TByteArray()             => t"_root_.scala.Array[Byte]".asRight
       case TNamedType(prefix, name) => identifier(prefix, name)
-      case TOption(value)           => t"_root_.scala.Option[${value.as[Type]}]"
-      case TEither(a, b)            => t"_root_.scala.Either[${a.as[Type]}, ${b.as[Type]}]"
-      case TMap(Some(key), value)   => t"_root_.scala.Predef.Map[${key.as[Type]}, ${value.as[Type]}]"
+      case TOption(value)           => value.as[Type].map(tpe => t"_root_.scala.Option[$tpe]")
+      case TEither(a, b) =>
+        (a.as[Type], b.as[Type]).mapN { case (aType, bType) => t"_root_.scala.Either[$aType, $bType]" }
+      case TMap(Some(key), value) =>
+        (key.as[Type], value.as[Type]).mapN { case (kType, vType) => t"_root_.scala.Predef.Map[$kType, $vType]" }
       case TMap(None, value) =>
-        t"_root_.scala.Predef.Map[_root_.java.lang.String, ${value.as[Type]}]" // Compatibility for Avro
-      case TGeneric(generic, tparams) => t"${generic.as[Type]}[..${tparams.map(_.as[Type])}]"
-      case TList(value)               => t"_root_.scala.List[${value.as[Type]}]"
-      case TContaining(values)        => q"..${values.map(_.as[Stat])}"
-      case TRequired(value)           => value
+        value
+          .as[Type]
+          .map(vType => t"_root_.scala.Predef.Map[_root_.java.lang.String, $vType]") // Compatibility for Avro
+      case TGeneric(generic, tparams) =>
+        for {
+          tpe <- generic.as[Type]
+          ts  <- tparams.traverse(_.as[Type])
+        } yield t"$tpe[..$ts]"
+      case TList(value)        => value.as[Type].map(tpe => t"_root_.scala.List[$tpe]")
+      case TContaining(values) => values.traverse(_.as[Stat]).map(ss => q"..$ss")
+      case TRequired(value)    => value.asRight
       case TCoproduct(invariants) =>
-        invariants.toList.foldRight[Type](t"_root_.shapeless.CNil") {
-          case (t, acc) => t"_root_.shapeless.:+:[${t.as[Type]}, ${acc.as[Type]}]"
+        invariants.toList.foldRight[Either[String, Type]](t"_root_.shapeless.CNil".asRight) {
+          case (t: Tree, acc: Either[String, Type]) =>
+            for {
+              tType   <- t.as[Type]
+              accType <- acc
+            } yield t"_root_.shapeless.:+:[$tType, $accType]"
         }
       case TSum(name, fields) =>
         val typeName   = Type.Name(name)
@@ -111,20 +151,23 @@ object codegen {
           ;
           val values = findValues
         }
-        """
+        """.asRight
       case TProduct(name, fields) =>
-        def arg(f: Field[_]) = {
-          val annotation = mod"@_root_.pbdirect.pbIndex(..${f.indices.map(Lit.Int(_))})"
-          param"$annotation ${Term.Name(f.name)}: ${Some(f.tpe.asInstanceOf[Type])}"
+        def arg(f: Field[Tree]): Either[String, Term.Param] =
+          f.tpe.as[Type].map { tpe =>
+            val annotation = mod"@_root_.pbdirect.pbIndex(..${f.indices.map(Lit.Int(_))})"
+            param"$annotation ${Term.Name(f.name)}: ${Some(tpe)}"
+          }
+        fields.traverse(arg).map { args =>
+          q"@message final case class ${Type.Name(name)}(..$args)"
         }
-        val args = fields.map(arg)
-        q"@message final case class ${Type.Name(name)}(..$args)"
     }
 
-    scheme.cata(algebra).apply(decl)
+    scheme.cataM(algebra).apply(decl)
   }
 
-  def service[T](srv: Service[T], streamCtor: (Type, Type) => Type.Apply)(implicit T: Basis[MuF, T]): Stat = {
+  def service[T](srv: Service[T], streamCtor: (Type, Type) => Type.Apply)(
+      implicit T: Basis[MuF, T]): Either[String, Stat] = {
     val serializationType = Term.Name(srv.serializationType.toString)
     val compressionType   = Term.Name(srv.compressionType.toString)
 
@@ -137,34 +180,44 @@ object codegen {
         mod"@service($serializationType, $compressionType)"
     }
 
-    q"""
-    @$serviceAnnotation trait ${Type.Name(srv.name)}[F[_]] {
-      ..${srv.operations.map(op => operation(op, streamCtor))}
+    srv.operations.traverse(op => operation(op, streamCtor)).map { ops =>
+      q"""
+      @$serviceAnnotation trait ${Type.Name(srv.name)}[F[_]] {
+        ..$ops
+      }
+      """
     }
-    """
   }
 
   def operation[T](op: Service.Operation[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Decl.Def =
-    q"def ${Term.Name(op.name)}(req: ${requestType(op.request, streamCtor)}): ${responseType(op.response, streamCtor)}"
+      implicit T: Basis[MuF, T]): Either[String, Decl.Def] =
+    for {
+      reqType  <- requestType(op.request, streamCtor)
+      respType <- responseType(op.response, streamCtor)
+    } yield q"def ${Term.Name(op.name)}(req: $reqType): $respType"
 
   def requestType[T](opType: Service.OperationType[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Type = {
-    val tpe = schema(opType.tpe).as[Type]
-
-    if (opType.stream)
-      streamCtor(Type.Name("F"), tpe)
-    else
-      tpe
-  }
+      implicit T: Basis[MuF, T]): Either[String, Type] =
+    for {
+      tree <- schema(opType.tpe)
+      tpe  <- tree.as[Type]
+    } yield {
+      if (opType.stream)
+        streamCtor(Type.Name("F"), tpe)
+      else
+        tpe
+    }
 
   def responseType[T](opType: Service.OperationType[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Type.Apply = {
-    val tpe = schema(opType.tpe).as[Type]
+      implicit T: Basis[MuF, T]): Either[String, Type.Apply] =
+    for {
+      tree <- schema(opType.tpe)
+      tpe  <- tree.as[Type]
+    } yield {
+      if (opType.stream)
+        streamCtor(Type.Name("F"), tpe)
+      else
+        t"F[$tpe]"
+    }
 
-    if (opType.stream)
-      streamCtor(Type.Name("F"), tpe)
-    else
-      t"F[$tpe]"
-  }
 }

--- a/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
@@ -159,7 +159,7 @@ object codegen {
             param"$annotation ${Term.Name(f.name)}: ${Some(tpe)}"
           }
         fields.traverse(arg).map { args =>
-          q"@message final case class ${Type.Name(name)}(..$args)"
+          q"@_root_.higherkindness.mu.rpc.protocol.message final case class ${Type.Name(name)}(..$args)"
         }
     }
 
@@ -173,11 +173,11 @@ object codegen {
 
     val serviceAnnotation = srv.idiomaticEndpoints match {
       case IdiomaticEndpoints(Some(pkg), true) =>
-        mod"@service($serializationType, $compressionType, namespace = Some($pkg), methodNameStyle = Capitalize)"
+        mod"@_root_.higherkindness.mu.rpc.protocol.service($serializationType, $compressionType, namespace = Some($pkg), methodNameStyle = Capitalize)"
       case IdiomaticEndpoints(None, true) =>
-        mod"@service($serializationType, $compressionType, methodNameStyle = Capitalize)"
+        mod"@_root_.higherkindness.mu.rpc.protocol.service($serializationType, $compressionType, methodNameStyle = Capitalize)"
       case _ =>
-        mod"@service($serializationType, $compressionType)"
+        mod"@_root_.higherkindness.mu.rpc.protocol.service($serializationType, $compressionType)"
     }
 
     srv.operations.traverse(op => operation(op, streamCtor)).map { ops =>

--- a/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
@@ -54,7 +54,7 @@ object codegen {
 
     def declaration(decl: T): Either[String, List[Stat]] =
       for {
-        tree <- schema(optimize(decl))
+        tree <- schema(decl)
         stat <- tree.as[Stat]
       } yield explodeBlock(stat)
 
@@ -163,7 +163,7 @@ object codegen {
         }
     }
 
-    scheme.cataM(algebra).apply(decl)
+    scheme.cataM(algebra).apply(optimize(decl))
   }
 
   def service[T](srv: Service[T], streamCtor: (Type, Type) => Type.Apply)(

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -28,6 +28,11 @@ import higherkindness.skeuomorph.mu.Optimize.nestedOptionInCoproduct
 import higherkindness.skeuomorph.mu.SerializationType._
 import higherkindness.droste._
 
+@deprecated(
+  message =
+    "This object will be removed soon. Please use higherkindness.skeuomorph.mu.codegen to generate a scalameta tree instead. You can call `.syntax` on the tree to get the Scala code as a String.",
+  since = "0.0.20"
+)
 object print {
 
   def schema[T: Project[MuF, ?]]: Printer[T] = {

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -43,34 +43,8 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
   def is = s2"""
   Protobuf Protocol
 
-  It should be possible to print a protocol from a Proto file. $printProtobufProtocol
-
-  It should be possible to generate Scala code for a protocol from a Proto file. $codegenProtobufProtocol
+  It should be possible to generate Scala code for a Mu protocol from a Proto file. $codegenProtobufProtocol
   """
-
-  def printProtobufProtocol = prop { (ct: CompressionType, useIdiom: Boolean) =>
-    val parseProtocol: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] = {
-      p: Protocol[Mu[ProtobufF]] =>
-        higherkindness.skeuomorph.mu.Protocol.fromProtobufProto(ct, useIdiom)(p)
-    }
-
-    val printProtocol: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] => String = {
-      p: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] =>
-        higherkindness.skeuomorph.mu.print.proto.print(p)
-    }
-
-    val actual   = (parseProtocol andThen printProtocol)(protobufProtocol)
-    val expected = expectation(ct, useIdiom)
-
-    (actual.clean must beEqualTo(expected.clean)) :| s"""
-      |Actual output:
-      |$actual
-      |
-      |
-      |Expected output:
-      |$expected"
-      """.stripMargin
-  }
 
   def codegenProtobufProtocol = prop { (ct: CompressionType, useIdiom: Boolean) =>
     val parseProtocol: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] = {
@@ -135,7 +109,8 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Predef.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
-      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.shapeless.:+:[_root_.scala.Long, _root_.shapeless.:+:[_root_.scala.Int, _root_.shapeless.:+:[_root_.java.lang.String, _root_.shapeless.:+:[_root_.com.acme.book.Book, _root_.shapeless.CNil]]]]]
+      |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.shapeless.:+:[_root_.scala.Long, _root_.shapeless.:+:[_root_.scala.Int, _root_.shapeless.:+:[_root_.java.lang.String, _root_.shapeless.:+:[_root_.com.acme.book.Book, _root_.shapeless.CNil]]]]],
+      |  @_root_.pbdirect.pbIndex(8,9) either: _root_.scala.Option[_root_.scala.Either[_root_.scala.Long, _root_.scala.Int]]
       |)
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -84,9 +84,11 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
 
     s"""package com.acme
       |
+      |import _root_.higherkindness.mu.rpc.protocol._
+      |
       |object book {
       |
-      |@_root_.higherkindness.mu.rpc.protocol.message final case class Book(
+      |@message final case class Book(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) title: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(3) author: _root_.scala.List[_root_.com.acme.author.Author],
@@ -95,17 +97,17 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(11) `private`: _root_.scala.Boolean,
       |  @_root_.pbdirect.pbIndex(16) `type`: _root_.scala.Option[_root_.com.acme.book.`type`]
       |)
-      |@_root_.higherkindness.mu.rpc.protocol.message final case class `type`(
+      |@message final case class `type`(
       |  @_root_.pbdirect.pbIndex(1) foo: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) thing: _root_.scala.Option[_root_.com.acme.`hyphenated-name`.Thing]
       |)
-      |@_root_.higherkindness.mu.rpc.protocol.message final case class GetBookRequest(
+      |@message final case class GetBookRequest(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long
       |)
-      |@_root_.higherkindness.mu.rpc.protocol.message final case class GetBookViaAuthor(
+      |@message final case class GetBookViaAuthor(
       |  @_root_.pbdirect.pbIndex(1) author: _root_.scala.Option[_root_.com.acme.author.Author]
       |)
-      |@_root_.higherkindness.mu.rpc.protocol.message final case class BookStore(
+      |@message final case class BookStore(
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Predef.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
@@ -130,7 +132,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  val values = findValues
       |}
       |
-      |@_root_.higherkindness.mu.rpc.protocol.service($serviceParams) trait BookService[F[_]] {
+      |@service($serviceParams) trait BookService[F[_]] {
       |  def GetBook(req: _root_.com.acme.book.GetBookRequest): F[_root_.com.acme.book.Book]
       |  def GetBooksViaAuthor(req: _root_.com.acme.book.GetBookViaAuthor): Stream[F, _root_.com.acme.book.Book]
       |  def GetGreatestBook(req: Stream[F, _root_.com.acme.book.GetBookRequest]): F[_root_.com.acme.book.Book]

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -84,8 +84,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
 
     val codegen: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] => String = {
       p: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] =>
-        val tree = higherkindness.skeuomorph.mu.codegen.protocol(p, streamCtor)
-        //println(tree.structure)
+        val tree = higherkindness.skeuomorph.mu.codegen.protocol(p, streamCtor).right.get
         tree.syntax
     }
 

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -82,17 +82,17 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       case (f: Type, a: Type) => t"Stream[$f, $a]"
     }
 
-    val codegen: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] => String = {
+    val codegen: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] => Pkg = {
       p: higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] =>
-        val tree = higherkindness.skeuomorph.mu.codegen.protocol(p, streamCtor).right.get
-        tree.syntax
+        higherkindness.skeuomorph.mu.codegen.protocol(p, streamCtor).right.get
     }
 
     val actual = (parseProtocol andThen codegen)(protobufProtocol)
 
-    val expected = expectation(ct, useIdiom)
+    val expected = expectation(ct, useIdiom).parse[Source].get.children.head.asInstanceOf[Pkg]
 
-    (actual.clean must beEqualTo(expected.clean)) :| s"""
+    import scala.meta.contrib._
+    actual.isEqual(expected) :| s"""
       |Actual output:
       |$actual
       |

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -86,7 +86,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |
       |object book {
       |
-      |@message final case class Book(
+      |@_root_.higherkindness.mu.rpc.protocol.message final case class Book(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) title: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(3) author: _root_.scala.List[_root_.com.acme.author.Author],
@@ -95,17 +95,17 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(11) `private`: _root_.scala.Boolean,
       |  @_root_.pbdirect.pbIndex(16) `type`: _root_.scala.Option[_root_.com.acme.book.`type`]
       |)
-      |@message final case class `type`(
+      |@_root_.higherkindness.mu.rpc.protocol.message final case class `type`(
       |  @_root_.pbdirect.pbIndex(1) foo: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) thing: _root_.scala.Option[_root_.com.acme.`hyphenated-name`.Thing]
       |)
-      |@message final case class GetBookRequest(
+      |@_root_.higherkindness.mu.rpc.protocol.message final case class GetBookRequest(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long
       |)
-      |@message final case class GetBookViaAuthor(
+      |@_root_.higherkindness.mu.rpc.protocol.message final case class GetBookViaAuthor(
       |  @_root_.pbdirect.pbIndex(1) author: _root_.scala.Option[_root_.com.acme.author.Author]
       |)
-      |@message final case class BookStore(
+      |@_root_.higherkindness.mu.rpc.protocol.message final case class BookStore(
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Predef.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
@@ -130,7 +130,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  val values = findValues
       |}
       |
-      |@service($serviceParams) trait BookService[F[_]] {
+      |@_root_.higherkindness.mu.rpc.protocol.service($serviceParams) trait BookService[F[_]] {
       |  def GetBook(req: _root_.com.acme.book.GetBookRequest): F[_root_.com.acme.book.Book]
       |  def GetBooksViaAuthor(req: _root_.com.acme.book.GetBookViaAuthor): Stream[F, _root_.com.acme.book.Book]
       |  def GetGreatestBook(req: Stream[F, _root_.com.acme.book.GetBookRequest]): F[_root_.com.acme.book.Book]

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -50,6 +50,11 @@ message BookStore {
         string iou_note = 6;
         Book barter = 7;
     }
+
+    oneof either {
+        int64 first = 8;
+        int32 second = 9;
+    }
 }
 
 enum Genre {


### PR DESCRIPTION
I find this easier to work with than the existing printer, which is basically doing fancy string concatenation, because scalameta gives us a nice AST with which to model the code. It also provides quasiquotes, which are very convenient, and it indents the code correctly for us.

(Unfortunately we end up losing a lot of the type information when we do a catamorphism, and we have to add it back in using casting. I haven't found a nice way around this. Open to suggestions.)

The codegen takes a stream type constructor as an argument, allowing the sbt plugin to choose between FS2 and Monix for streaming more cleanly than it does currently. It also includes an `import higherkindess.mu.rpc.protocol._` statement so we don't have to add the import in the sbt plugin.

If people are happy with the scalameta approach, I suggest we remove `higherkindness.skeuomorph.mu.print` and update the Mu sbt plugin to use the new scalameta-based codegen. In future we could also migrate the OpenAPI codegen to scalameta. In this PR I've kept `higherkindness.skeuomorph.mu.print` but added a `@deprecated` annotation.