### PR TITLE
Support protobuf nested messages and enums

### DIFF
--- a/docs/docs/docs/optimizations.md
+++ b/docs/docs/docs/optimizations.md
@@ -47,17 +47,19 @@ they're inside a product themselves.  And we do this with the
 
 ```scala mdoc
 def nestedNamedTypesTrans[T](implicit T: Basis[MuF, T]): Trans[MuF, MuF, T] = Trans {
-  case TProduct(name, fields) =>
+  case TProduct(name, fields, np, nc) =>
     def nameTypes(f: Field[T]): Field[T] = f.copy(tpe = namedTypes(T)(f.tpe))
     TProduct[T](
       name,
-      fields.map(nameTypes)
+      fields.map(nameTypes),
+      np,
+      nc
     )
   case other => other
 }
 
 def namedTypesTrans[T]: Trans[MuF, MuF, T] = Trans {
-  case TProduct(name, _) => TNamedType[T](Nil, name)
+  case TProduct(name, _, _, _) => TNamedType[T](Nil, name)
   case TSum(name, _)     => TNamedType[T](Nil, name)
   case other             => other
 }

--- a/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
@@ -99,7 +99,7 @@ object Protocol {
     case MuF.TRequired(t)           => T.coalgebra(t)
     case MuF.TCoproduct(invariants) => AvroF.union(invariants)
     case MuF.TSum(name, fields)     => AvroF.enum(name, none[String], Nil, none[String], fields.map(_.name))
-    case MuF.TProduct(name, fields) =>
+    case MuF.TProduct(name, fields, _, _) =>
       TRecord(
         name,
         none[String],

--- a/src/main/scala/higherkindness/skeuomorph/mu/Optimize.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Optimize.scala
@@ -43,11 +43,13 @@ object Optimize {
    * }}}
    */
   def nestedNamedTypesTrans[T](implicit T: Basis[MuF, T]): Trans[MuF, MuF, T] = Trans {
-    case TProduct(name, fields) =>
+    case TProduct(name, fields, nestedProducts, nestedCoproducts) =>
       def nameTypes(f: Field[T]): Field[T] = f.copy(tpe = namedTypes(T)(f.tpe))
       TProduct[T](
         name,
-        fields.map(nameTypes)
+        fields.map(nameTypes),
+        nestedProducts,
+        nestedCoproducts
       )
     case other => other
   }
@@ -63,9 +65,9 @@ object Optimize {
   }
 
   def namedTypesTrans[T]: Trans[MuF, MuF, T] = Trans {
-    case TProduct(name, _) => TNamedType[T](Nil, name)
-    case TSum(name, _)     => TNamedType[T](Nil, name)
-    case other             => other
+    case TProduct(name, _, _, _) => TNamedType[T](Nil, name)
+    case TSum(name, _)           => TNamedType[T](Nil, name)
+    case other                   => other
   }
 
   def namedTypes[T: Basis[MuF, ?]]: T => T              = scheme.cata(namedTypesTrans.algebra)

--- a/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/Transform.scala
@@ -48,10 +48,11 @@ object Transform {
     case ProtobufF.TOptionalNamedType(prefix, name) => TOption(A.algebra(TNamedType(prefix, name)))
     case ProtobufF.TRepeated(value)                 => TList(value)
     case ProtobufF.TEnum(name, symbols, _, _)       => TSum(name, symbols.map(SumField.tupled))
-    case ProtobufF.TMessage(name, fields, _)        => TProduct(name, fields.map(f => Field(f.name, f.tpe, f.indices)))
-    case ProtobufF.TFileDescriptor(values, _, _)    => TContaining(values)
-    case ProtobufF.TOneOf(_, fields)                => TOption(A.algebra(TCoproduct(fields.map(_.tpe))))
-    case ProtobufF.TMap(key, values)                => TMap(Some(key), values)
+    // TODO how shall we add the nested stuff to MuF?
+    case ProtobufF.TMessage(name, fields, _, _, _) => TProduct(name, fields.map(f => Field(f.name, f.tpe, f.indices)))
+    case ProtobufF.TFileDescriptor(values, _, _)   => TContaining(values)
+    case ProtobufF.TOneOf(_, fields)               => TOption(A.algebra(TCoproduct(fields.map(_.tpe))))
+    case ProtobufF.TMap(key, values)               => TMap(Some(key), values)
   }
 
   def transformAvro[A]: Trans[AvroF, MuF, A] = Trans {

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Comparison.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Comparison.scala
@@ -176,8 +176,11 @@ object Comparison extends ComparisonInstances {
               .toList
               .toMap)
         case (TSum(n, f), TSum(n2, f2)) if (n === n2 && f.forall(f2.toSet)) => same
-        case (TProduct(n, f), TProduct(n2, f2)) if (n === n2) =>
-          CompareList(zipFields(path / Name(n), f, f2))
+        case (TProduct(n, f, np, nc), TProduct(n2, f2, np2, nc2)) if (n === n2) =>
+          val fields           = zipFields(path / Name(n), f, f2)
+          val nestedProducts   = zipLists(path, np, np2, _ => Name(n))
+          val nestedCoproducts = zipLists(path, nc, nc2, _ => Name(n))
+          CompareList(fields ++ nestedProducts ++ nestedCoproducts)
 
         // Numeric widdening
         case (TInt(), TLong() | TFloat() | TDouble()) | (TLong(), TFloat() | TDouble()) | (TFloat(), TDouble()) =>

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Path.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Path.scala
@@ -31,6 +31,8 @@ object PathElement {
   final case object RightBranch               extends PathElement
   final case object GenericType               extends PathElement
   final case class GenericParameter(idx: Int) extends PathElement
+  final case class NestedProduct(idx: Int)    extends PathElement
+  final case class NestedCoproduct(idx: Int)  extends PathElement
 
   implicit val pathElementShow: Show[PathElement] = Show.show {
     case Name(v)             => v
@@ -44,6 +46,8 @@ object PathElement {
     case RightBranch         => "$right"
     case GenericType         => "$gtype"
     case GenericParameter(i) => s"$$tparam[$i]"
+    case NestedProduct(i)    => s"nested-product[$i]"
+    case NestedCoproduct(i)  => s"nested-coproduct[$i]"
   }
 }
 

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Path.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Path.scala
@@ -31,8 +31,6 @@ object PathElement {
   final case object RightBranch               extends PathElement
   final case object GenericType               extends PathElement
   final case class GenericParameter(idx: Int) extends PathElement
-  final case class NestedProduct(idx: Int)    extends PathElement
-  final case class NestedCoproduct(idx: Int)  extends PathElement
 
   implicit val pathElementShow: Show[PathElement] = Show.show {
     case Name(v)             => v
@@ -46,8 +44,6 @@ object PathElement {
     case RightBranch         => "$right"
     case GenericType         => "$gtype"
     case GenericParameter(i) => s"$$tparam[$i]"
-    case NestedProduct(i)    => s"nested-product[$i]"
-    case NestedCoproduct(i)  => s"nested-coproduct[$i]"
   }
 }
 

--- a/src/main/scala/higherkindness/skeuomorph/mu/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/print.scala
@@ -73,7 +73,7 @@ object print {
       |  val values = findValues
       |}
       """.stripMargin
-      case TProduct(name, fields) =>
+      case TProduct(name, fields, _, _) =>
         def printField(f: Field[_]) =
           s"@_root_.pbdirect.pbIndex(${f.indices.mkString(",")}) ${toValidIdentifier(f.name)}: ${f.tpe}"
         val printFields = fields.map(printField).mkString(",\n  ")

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -303,7 +303,10 @@ object ParseProto {
     fields.count(f => (f.getNumber == 1 && f.getName == "key") || (f.getNumber == 2 && f.getName == "value")) == 2
 
   def matchNameEntry(name: String, source: DescriptorProto): Boolean =
-    source.getName.toLowerCase == s"${name}Entry".toLowerCase
+    normalizeName(source.getName) == normalizeName(s"${name}Entry")
+
+  def normalizeName(name: String): String =
+    name.toLowerCase.replaceAllLiterally("_", "")
 
   def fromOneofDescriptorsProto[A](
       oneOfFields: List[OneofDescriptorProto],

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -186,10 +186,11 @@ object ParseProto {
     // TODO need to include nested messages here
     message[A](
       name = descriptor.getName,
-      // TODO sort fields by index (doesn't really matter but that would be the least surprising behaviour)
-      fields = fields ++ oneOfFields.map(_._1),
+      fields = (fields ++ oneOfFields.map(_._1)).sortBy(_.indices.headOption),
       reserved = descriptor.getReservedRangeList.asScala.toList.map(range =>
-        (range.getStart until range.getEnd).map(_.toString).toList)
+        (range.getStart until range.getEnd).map(_.toString).toList),
+      nestedMessages = Nil,
+      nestedEnums = Nil
     ).embed
   }
 

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/print.scala
@@ -63,9 +63,9 @@ object print {
           }
           .mkString("\n  ")
 
-      val printNestedMessages = m.nestedMessages.map(messageToString).mkString("\n")
+      val printNestedMessages = m.nestedMessages.mkString("\n")
 
-      val printNestedEnums = m.nestedEnums.map(enumToString).mkString("\n")
+      val printNestedEnums = m.nestedEnums.mkString("\n")
 
       s"""
       |message ${m.name} {

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/print.scala
@@ -26,69 +26,81 @@ object print {
 
   def printOption(o: OptionValue): String = s"${o.name} = ${o.value}"
 
-  def printSchema[T: Basis[ProtobufF, ?]]: Printer[T] = {
-    val algebra: Algebra[ProtobufF, String] = Algebra {
-      case TNull()                     => "null"
-      case TDouble()                   => "double"
-      case TFloat()                    => "float"
-      case TInt32()                    => "int32"
-      case TInt64()                    => "int64"
-      case TUint32()                   => "uint32"
-      case TUint64()                   => "uint64"
-      case TSint32()                   => "sint32"
-      case TSint64()                   => "sint64"
-      case TFixed32()                  => "fixed32"
-      case TFixed64()                  => "fixed64"
-      case TSfixed32()                 => "sfixed32"
-      case TSfixed64()                 => "sfixed64"
-      case TBool()                     => "bool"
-      case TString()                   => "string"
-      case TBytes()                    => "bytes"
-      case TNamedType(_, name)         => name
-      case TOptionalNamedType(_, name) => s"optional $name"
-      case TRepeated(value)            => s"repeated $value"
-      case TMap(key, value)            => s"map<$key, $value>"
+  def printSchema[T](implicit T: Basis[ProtobufF, T]): Printer[T] = {
 
-      case TFileDescriptor(values, _, packageName) => s"package $packageName; \n ${values.mkString("\n")}"
+    def enumToString(e: TEnum[String]): String = {
+      val printOptions = e.options.map(o => s"\toption ${o.name} = ${o.value};").mkString("\n")
+      val printSymbols = e.symbols.map({ case (s, i) => s"\t$s = $i;" }).mkString("\n")
+      val printAliases = e.aliases.map({ case (s, i) => s"\t$s = $i;" }).mkString("\n")
 
-      case TEnum(name, symbols, options, aliases) =>
-        val printOptions = options.map(o => s"\toption ${o.name} = ${o.value};").mkString("\n")
-        val printSymbols = symbols.map({ case (s, i) => s"\t$s = $i;" }).mkString("\n")
-        val printAliases = aliases.map({ case (s, i) => s"\t$s = $i;" }).mkString("\n")
-        s"""
-      |enum $name {
+      s"""
+      |enum ${e.name} {
       |$printOptions
       |$printSymbols
       |$printAliases
       |}
       """.stripMargin
+    }
 
-      case TMessage(name, fields, reserved) =>
-        val printReserved: String = reserved
-          .map(l => s"reserved " + l.mkString(start = "", sep = ", ", end = ";"))
+    def messageToString(m: TMessage[String]): String = {
+      val printReserved: String = m.reserved
+        .map(l => s"reserved " + l.mkString(start = "", sep = ", ", end = ";"))
+        .mkString("\n  ")
+
+      def printOptions(options: List[OptionValue]) =
+        if (options.isEmpty)
+          ""
+        else
+          options.map(printOption).mkString(start = " [", sep = ", ", end = "]")
+
+      val printFields =
+        m.fields
+          .map {
+            case f: Field[String] =>
+              s"${f.tpe} ${f.name} = ${f.position}${printOptions(f.options)};"
+            case oneOf: OneOfField[String] =>
+              s"${oneOf.tpe}"
+          }
           .mkString("\n  ")
-        def printOptions(options: List[OptionValue]) =
-          if (options.isEmpty)
-            ""
-          else
-            options.map(printOption).mkString(start = " [", sep = ", ", end = "]")
 
-        val printFields =
-          fields
-            .map {
-              case f: Field[String] =>
-                s"${f.tpe} ${f.name} = ${f.position}${printOptions(f.options)};"
-              case oneOf: OneOfField[String] =>
-                s"${oneOf.tpe}"
-            }
-            .mkString("\n  ")
-        s"""
-      |message $name {
+      val printNestedMessages = m.nestedMessages.map(messageToString).mkString("\n")
+
+      val printNestedEnums = m.nestedEnums.map(enumToString).mkString("\n")
+
+      s"""
+      |message ${m.name} {
       |  $printReserved
       |  $printFields
+      |  $printNestedMessages
+      |  $printNestedEnums
       |}
       """.stripMargin
+    }
 
+    val algebra: Algebra[ProtobufF, String] = Algebra {
+      case TNull()                                 => "null"
+      case TDouble()                               => "double"
+      case TFloat()                                => "float"
+      case TInt32()                                => "int32"
+      case TInt64()                                => "int64"
+      case TUint32()                               => "uint32"
+      case TUint64()                               => "uint64"
+      case TSint32()                               => "sint32"
+      case TSint64()                               => "sint64"
+      case TFixed32()                              => "fixed32"
+      case TFixed64()                              => "fixed64"
+      case TSfixed32()                             => "sfixed32"
+      case TSfixed64()                             => "sfixed64"
+      case TBool()                                 => "bool"
+      case TString()                               => "string"
+      case TBytes()                                => "bytes"
+      case TNamedType(_, name)                     => name
+      case TOptionalNamedType(_, name)             => s"optional $name"
+      case TRepeated(value)                        => s"repeated $value"
+      case TMap(key, value)                        => s"map<$key, $value>"
+      case TFileDescriptor(values, _, packageName) => s"package $packageName; \n ${values.mkString("\n")}"
+      case e: TEnum[String]                        => enumToString(e)
+      case m: TMessage[String]                     => messageToString(m)
       case TOneOf(name, fields) =>
         val printFields =
           fields
@@ -97,10 +109,10 @@ object print {
             .mkString("\n  ")
 
         s"""
-      |oneof $name {
-      |  $printFields
-      |}
-      """.stripMargin
+        |oneof $name {
+        |  $printFields
+        |}
+        """.stripMargin
     }
 
     Printer.print(scheme.cata(algebra))

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -139,8 +139,13 @@ object instances {
         Gen.nonEmptyListOf(T.arbitrary) map { l =>
           MuF.coproduct[T](NonEmptyList.fromListUnsafe(l))
         },
-        (nonEmptyString, Gen.nonEmptyListOf(Gen.lzy(fieldGen))).mapN { (n, f) =>
-          MuF.product(n, f)
+        (
+          nonEmptyString,
+          Gen.nonEmptyListOf(Gen.lzy(fieldGen)),
+          Gen.listOfN(1, T.arbitrary),
+          Gen.listOfN(1, T.arbitrary)
+        ).mapN { (n, f, p, c) =>
+          MuF.product(n, f, p, c)
         }
       ))
   }
@@ -364,11 +369,10 @@ object instances {
     }
 
     for {
-      name  <- nonEmptyString
-      field <- sampleField
-      // these return a list of size 0 or 1, so it won't recurse forever
-      nestedMessages <- Gen.listOfN(1, protobufFMessage[T])
-      nestedEnums    <- Gen.listOfN(1, protobufFEnum[T])
+      name           <- nonEmptyString
+      field          <- sampleField
+      nestedMessages <- Gen.listOfN(1, T.arbitrary)
+      nestedEnums    <- Gen.listOfN(1, T.arbitrary)
     } yield ProtobufF.TMessage(name, List(field), Nil, nestedMessages, nestedEnums)
   }
 

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -95,7 +95,8 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(9) binding_type: _root_.scala.Option[_root_.com.acme.book.BindingType],
       |  @_root_.pbdirect.pbIndex(10) rating: _root_.scala.Option[_root_.com.acme.rating.Rating],
       |  @_root_.pbdirect.pbIndex(11) `private`: _root_.scala.Boolean,
-      |  @_root_.pbdirect.pbIndex(16) `type`: _root_.scala.Option[_root_.com.acme.book.`type`]
+      |  @_root_.pbdirect.pbIndex(16) `type`: _root_.scala.Option[_root_.com.acme.book.`type`],
+      |  @_root_.pbdirect.pbIndex(17) nearest_copy: _root_.scala.Option[_root_.com.acme.book.BookStore.Location]
       |)
       |@message final case class `type`(
       |  @_root_.pbdirect.pbIndex(1) foo: _root_.scala.Long,
@@ -112,8 +113,29 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Predef.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
       |  @_root_.pbdirect.pbIndex(4,5,6,7) payment_method: _root_.scala.Option[_root_.shapeless.:+:[_root_.scala.Long, _root_.shapeless.:+:[_root_.scala.Int, _root_.shapeless.:+:[_root_.java.lang.String, _root_.shapeless.:+:[_root_.com.acme.book.Book, _root_.shapeless.CNil]]]]],
-      |  @_root_.pbdirect.pbIndex(8,9) either: _root_.scala.Option[_root_.scala.Either[_root_.scala.Long, _root_.scala.Int]]
+      |  @_root_.pbdirect.pbIndex(8,9) either: _root_.scala.Option[_root_.scala.Either[_root_.scala.Long, _root_.scala.Int]],
+      |  @_root_.pbdirect.pbIndex(10) location: _root_.scala.Option[_root_.com.acme.book.BookStore.Location],
+      |  @_root_.pbdirect.pbIndex(11) coffee_quality: _root_.scala.Option[_root_.com.acme.book.BookStore.CoffeeQuality]
       |)
+      |object BookStore {
+      |  @message final case class Location(
+      |    @_root_.pbdirect.pbIndex(1) town: _root_.java.lang.String,
+      |    @_root_.pbdirect.pbIndex(2) country: _root_.scala.Option[_root_.com.acme.book.BookStore.Location.Country]
+      |  )
+      |  object Location {
+      |    @message final case class Country(
+      |      @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
+      |      @_root_.pbdirect.pbIndex(2) iso_code: _root_.java.lang.String
+      |    )
+      |  }
+      |  sealed abstract class CoffeeQuality(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
+      |  object CoffeeQuality extends _root_.enumeratum.values.IntEnum[CoffeeQuality] {
+      |    case object DELICIOUS extends CoffeeQuality(0)
+      |    case object DRINKABLE extends CoffeeQuality(1)
+      |
+      |    val values = findValues
+      |  }
+      |}
       |
       |sealed abstract class Genre(val value: _root_.scala.Int) extends _root_.enumeratum.values.IntEnumEntry
       |object Genre extends _root_.enumeratum.values.IntEnum[Genre] {

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/models/opencensus/resource.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/models/opencensus/resource.proto
@@ -1,0 +1,27 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Changes from original:
+// 1. Removed comments and newlines
+// 2. Removed protobuf options
+
+syntax = "proto3";
+
+package opencensus.proto.resource.v1;
+
+message Resource {
+  string type = 1;
+  map<string,string> labels = 2;
+}
+

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/models/opencensus/trace.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/models/opencensus/trace.proto
@@ -1,0 +1,133 @@
+// Copyright 2018, OpenCensus Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Changes from original:
+// 1. Removed comments and newlines
+// 2. Removed protobuf options
+// 3. Removed all fields that depend on Google protobuf definitions.
+
+syntax = "proto3";
+
+package opencensus.proto.trace.v1;
+
+import "models/opencensus/resource.proto";
+
+message Span {
+  bytes trace_id = 1;
+  bytes span_id = 2;
+  message Tracestate {
+    message Entry {
+      string key = 1;
+      string value = 2;
+    }
+    repeated Entry entries = 1;
+  }
+  Tracestate tracestate = 15;
+  bytes parent_span_id = 3;
+  TruncatableString name = 4;
+  enum SpanKind {
+    SPAN_KIND_UNSPECIFIED = 0;
+    SERVER = 1;
+    CLIENT = 2;
+  }
+  SpanKind kind = 14;
+  message Attributes {
+    map<string, AttributeValue> attribute_map = 1;
+    int32 dropped_attributes_count = 2;
+  }
+  Attributes attributes = 7;
+  StackTrace stack_trace = 8;
+  message TimeEvent {
+    message Annotation {
+      TruncatableString description = 1;
+      Attributes attributes = 2;
+    }
+    message MessageEvent {
+      enum Type {
+        TYPE_UNSPECIFIED = 0;
+        SENT = 1;
+        RECEIVED = 2;
+      }
+      Type type = 1;
+      uint64 id = 2;
+      uint64 uncompressed_size = 3;
+      uint64 compressed_size = 4;
+    }
+    oneof value {
+      Annotation annotation = 2;
+      MessageEvent message_event = 3;
+    }
+  }
+  message TimeEvents {
+    repeated TimeEvent time_event = 1;
+    int32 dropped_annotations_count = 2;
+    int32 dropped_message_events_count = 3;
+  }
+  TimeEvents time_events = 9;
+  message Link {
+    bytes trace_id = 1;
+    bytes span_id = 2;
+    enum Type {
+      TYPE_UNSPECIFIED = 0;
+      CHILD_LINKED_SPAN = 1;
+      PARENT_LINKED_SPAN = 2;
+    }
+    Type type = 3;
+    Attributes attributes = 4;
+  }
+  message Links {
+    repeated Link link = 1;
+    int32 dropped_links_count = 2;
+  }
+  Links links = 10;
+  Status status = 11;
+  opencensus.proto.resource.v1.Resource resource = 16;
+}
+message Status {
+  int32 code = 1;
+  string message = 2;
+}
+message AttributeValue {
+  oneof value {
+    TruncatableString string_value = 1;
+    int64 int_value = 2;
+    bool bool_value = 3;
+    double double_value = 4;
+  }
+}
+message StackTrace {
+  message StackFrame {
+    TruncatableString function_name = 1;
+    TruncatableString original_function_name = 2;
+    TruncatableString file_name = 3;
+    int64 line_number = 4;
+    int64 column_number = 5;
+    Module load_module = 6;
+    TruncatableString source_version = 7;
+  }
+  message StackFrames {
+    repeated StackFrame frame = 1;
+    int32 dropped_frames_count = 2;
+  }
+  StackFrames stack_frames = 1;
+  uint64 stack_trace_hash_id = 2;
+}
+message Module {
+  TruncatableString module = 1;
+  TruncatableString build_id = 2;
+}
+message TruncatableString {
+  string value = 1;
+  int32 truncated_byte_count = 2;
+}

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/service/book.proto
@@ -16,6 +16,7 @@ message Book {
     Rating rating = 10;
     bool private = 11; // note: private is a reserved word in Scala
     type type = 16; // note: using "type" (a reserved word) as both the field type and field name
+    BookStore.Location nearest_copy = 17;
 }
 
 message type { // note: type is a reserved word in Scala
@@ -40,6 +41,15 @@ service BookService {
 }
 
 message BookStore {
+    message Location {
+        message Country {
+            string name = 1;
+            string iso_code = 2;
+        }
+        string town = 1;
+        Country country = 2;
+    }
+
     string name = 1;
     map<int64, string> books = 2;
     repeated Genre genres = 3;
@@ -55,6 +65,16 @@ message BookStore {
         int64 first = 8;
         int32 second = 9;
     }
+
+    Location location = 10;
+
+    enum CoffeeQuality {
+      DELICIOUS = 0;
+      DRINKABLE = 1;
+    }
+
+    CoffeeQuality coffee_quality = 11;
+
 }
 
 enum Genre {


### PR DESCRIPTION
In `.proto` files it is possible (and quite common) to nest messages and enums inside other messages, and reference them for field types in other message, e.g.

```protobuf
message Person {
  message Name {
    string given_name = 1;
    string family_name = 2;
  }

  Name name = 1;
  int32 date_of_birth = 2;
}

message User {  
  enum Type {
    NORMAL = 0;
    ADMIN = 1;
  }

  int32 id = 1;
  Person.Name name = 2;
  Type type = 3;  
} 
```

This PR adds support for these nested types.

Sorry the diff is pretty huge, but the major changes are:

1. Correctly build the fully-qualified names for nested types when parsing a `.proto` file. (We were generating nonsense names because the logic wasn't written with nested types in mind.)
2. Make sure to collect all messages and enums when parsing a `.proto` file, no matter how deeply nested they are. (We were only looking for messages at one level of nesting, and not picking up nested enums at all.)
3. Add a message's lists of nested messages and enums to `ProtobufF.TMessage`
4. Also add them to `MuF.TProduct` and populate them when transforming from `ProtobufF` to `MuF`
5. Trivially set them to `Nil` when transforming from `AvroF` to `MuF` for now. Avro schemas do support nested records, so we might want to change this in the future.
6. Generate the appropriate scalameta trees for nested types when doing codegen
7. Update the comparison logic to handle nested types, and add a test for it
8. Extend the `ProtobufProtocolSpec` to test the new functionality

The generated code for the above example would look like (slightly simplified):

```scala
case class Person(name: Option[Person.Name], date_of_birth: Int)
object Person {
  case class Name(given_name: String, family_name: String)
}

case class User(id: Int, name: Person.Name, `type`: User.Type)
object User {
  sealed trait Type
  case object NORMAL extends Type
  case object ADMIN extends Type
}
```