### PR TITLE
Remove `@message` annotation from generated case classes

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/FileUtils.scala
+++ b/src/main/scala/higherkindness/skeuomorph/FileUtils.scala
@@ -25,21 +25,15 @@ object FileUtils {
   def fileHandle[F[_]: Sync](name: String): Resource[F, File] =
     Resource.make(
       Sync[F].delay(new File(name))
-    )(
-      file => Sync[F].delay(file.deleteOnExit())
-    )
+    )(file => Sync[F].delay(file.deleteOnExit()))
 
   def fileOutputStream[F[_]: Sync](file: File): Resource[F, FileOutputStream] =
     Resource.make(
       Sync[F].delay(new FileOutputStream(file))
-    )(
-      fos => Sync[F].delay(fos.close())
-    )
+    )(fos => Sync[F].delay(fos.close()))
 
   def fileInputStream[F[_]: Sync](name: String): Resource[F, InputStream] =
     Resource.make(
       Sync[F].delay(Files.newInputStream(Paths.get(name), StandardOpenOption.DELETE_ON_CLOSE))
-    )(
-      is => Sync[F].delay(is.close())
-    )
+    )(is => Sync[F].delay(is.close()))
 }

--- a/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
@@ -105,7 +105,8 @@ object Protocol {
         none[String],
         Nil,
         none[String],
-        fields.map(f => Field(f.name, Nil, none[String], none[Order], f.tpe)))
+        fields.map(f => Field(f.name, Nil, none[String], none[Order], f.tpe))
+      )
   }
 
   def fromFreesFProtocol[T, U](protocol: mu.Protocol[T])(implicit T: Basis[MuF, T], U: Basis[AvroF, U]): Protocol[U] = {

--- a/src/main/scala/higherkindness/skeuomorph/avro/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/schema.scala
@@ -100,15 +100,15 @@ object AvroF {
       namespace: Option[String],
       aliases: List[String],
       doc: Option[String],
-      fields: List[Field[A]])
-      extends AvroF[A]
+      fields: List[Field[A]]
+  ) extends AvroF[A]
   final case class TEnum[A](
       name: String,
       namespace: Option[String],
       aliases: List[String],
       doc: Option[String],
-      symbols: List[String])
-      extends AvroF[A]
+      symbols: List[String]
+  ) extends AvroF[A]
   final case class TUnion[A](options: NonEmptyList[A])                                                  extends AvroF[A]
   final case class TFixed[A](name: String, namespace: Option[String], aliases: List[String], size: Int) extends AvroF[A]
 
@@ -153,13 +153,15 @@ object AvroF {
       namespace: Option[String],
       aliases: List[String],
       doc: Option[String],
-      fields: List[Field[A]]): AvroF[A] = TRecord(name, namespace, aliases, doc, fields)
+      fields: List[Field[A]]
+  ): AvroF[A] = TRecord(name, namespace, aliases, doc, fields)
   def enum[A](
       name: String,
       namespace: Option[String],
       aliases: List[String],
       doc: Option[String],
-      symbols: List[String]): AvroF[A]             = TEnum(name, namespace, aliases, doc, symbols)
+      symbols: List[String]
+  ): AvroF[A]                                      = TEnum(name, namespace, aliases, doc, symbols)
   def union[A](options: NonEmptyList[A]): AvroF[A] = TUnion(options)
   def fixed[A](name: String, namespace: Option[String], aliases: List[String], size: Int): AvroF[A] =
     TFixed(name, namespace, aliases, size)

--- a/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/codegen.scala
@@ -206,7 +206,7 @@ object codegen {
           nestedCoproducts.traverse(_.as[Stat])
         ).mapN {
           case (args, prods, coprods) =>
-            val caseClass = q"@message final case class ${Type.Name(name)}(..$args)"
+            val caseClass = q"final case class ${Type.Name(name)}(..$args)"
             if (prods.nonEmpty || coprods.nonEmpty) {
               q"""
             $caseClass
@@ -226,7 +226,8 @@ object codegen {
   }
 
   def service[T](srv: Service[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Either[String, Stat] = {
+      implicit T: Basis[MuF, T]
+  ): Either[String, Stat] = {
     val serializationType = Term.Name(srv.serializationType.toString)
     val compressionType   = Term.Name(srv.compressionType.toString)
 
@@ -249,14 +250,16 @@ object codegen {
   }
 
   def operation[T](op: Service.Operation[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Either[String, Decl.Def] =
+      implicit T: Basis[MuF, T]
+  ): Either[String, Decl.Def] =
     for {
       reqType  <- requestType(op.request, streamCtor)
       respType <- responseType(op.response, streamCtor)
     } yield q"def ${Term.Name(op.name)}(req: $reqType): $respType"
 
   def requestType[T](opType: Service.OperationType[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Either[String, Type] =
+      implicit T: Basis[MuF, T]
+  ): Either[String, Type] =
     for {
       tree <- schema(opType.tpe)
       tpe  <- tree.as[Type]
@@ -268,7 +271,8 @@ object codegen {
     }
 
   def responseType[T](opType: Service.OperationType[T], streamCtor: (Type, Type) => Type.Apply)(
-      implicit T: Basis[MuF, T]): Either[String, Type.Apply] =
+      implicit T: Basis[MuF, T]
+  ): Either[String, Type.Apply] =
     for {
       tree <- schema(opType.tpe)
       tpe  <- tree.as[Type]

--- a/src/main/scala/higherkindness/skeuomorph/mu/comparison/Comparison.scala
+++ b/src/main/scala/higherkindness/skeuomorph/mu/comparison/Comparison.scala
@@ -130,7 +130,8 @@ object Comparison extends ComparisonInstances {
                 .getOrElse(Result.mismatch(UnionMemberRemoved(p)))
           }
           .toList
-          .combineAll)
+          .combineAll
+      )
 
     case MatchInList(res, rep) =>
       val firstMatch = res.find(Result.isMatch)
@@ -171,10 +172,12 @@ object Comparison extends ComparisonInstances {
               .map {
                 case (item, idx) =>
                   path / Alternative(idx) -> (List(item.some), i2.toList.map(_.some)).tupled.map(p =>
-                    (path / Alternative(idx), p._1, p._2))
+                    (path / Alternative(idx), p._1, p._2)
+                  )
               }
               .toList
-              .toMap)
+              .toMap
+          )
         case (TSum(n, f), TSum(n2, f2)) if (n === n2 && f.forall(f2.toSet)) => same
         case (TProduct(n, f, np, nc), TProduct(n2, f2, np2, nc2)) if (n === n2) =>
           val fields           = zipFields(path / Name(n), f, f2)
@@ -206,7 +209,8 @@ object Comparison extends ComparisonInstances {
         case (TOption(i1), TEither(r1, r2)) =>
           MatchInList(
             Vector((path, i1.some, r1.some), (path, i1.some, r2.some)),
-            Reporter.promotedToEither(path, reader))
+            Reporter.promotedToEither(path, reader)
+          )
 
         case (TEither(l1, r1), TCoproduct(rs)) =>
           AlignUnionMembers(

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonDecoders.scala
@@ -61,7 +61,8 @@ object JsonDecoders {
       for {
         values <- c.downField("enum").as[List[String]]
         _      <- validateType(c, "string")
-      } yield JsonSchemaF.enum[A](values).embed)
+      } yield JsonSchemaF.enum[A](values).embed
+    )
 
   private def sumJsonSchemaDecoder[A: Embed[JsonSchemaF, ?]]: Decoder[A] =
     Decoder.instance(_.downField("oneOf").as[List[A]].map(JsonSchemaF.sum[A](_).embed))
@@ -72,7 +73,8 @@ object JsonDecoders {
         c.downField(name)
           .success
           .fold(DecodingFailure(s"$name property does not exist", c.history).asLeft[Unit])(_ =>
-            ().asRight[DecodingFailure])
+            ().asRight[DecodingFailure]
+          )
       def isObject: Decoder.Result[Unit] =
         validateType(c, "object") orElse
           propertyExists("properties") orElse
@@ -121,7 +123,8 @@ object JsonDecoders {
       "default",
       "description"
     )((enum: Option[List[String]], default: String, description: Option[String]) =>
-      Server.Variable(enum.getOrElse(List.empty), default, description))
+      Server.Variable(enum.getOrElse(List.empty), default, description)
+    )
 
   implicit val serverDecoder: Decoder[Server] =
     Decoder.forProduct3(
@@ -164,15 +167,17 @@ object JsonDecoders {
           headers: Option[Map[String, Either[Header[A], Reference]]],
           style: Option[String],
           explode: Option[Boolean],
-          allowReserved: Option[Boolean]) =>
-        Encoding(contentType, headers.getOrElse(Map.empty), style, explode, allowReserved))
+          allowReserved: Option[Boolean]
+      ) => Encoding(contentType, headers.getOrElse(Map.empty), style, explode, allowReserved)
+    )
 
   implicit def mediaTypeDecoder[A: Decoder]: Decoder[MediaType[A]] =
     Decoder.forProduct2(
       "schema",
       "encoding"
     )((schema: Option[A], encoding: Option[Map[String, Encoding[A]]]) =>
-      MediaType(schema, encoding.getOrElse(Map.empty)))
+      MediaType(schema, encoding.getOrElse(Map.empty))
+    )
 
   implicit def requestDecoder[A: Decoder]: Decoder[Request[A]] =
     Decoder.forProduct3(
@@ -180,7 +185,8 @@ object JsonDecoders {
       "content",
       "required"
     )((description: Option[String], content: Map[String, MediaType[A]], required: Option[Boolean]) =>
-      Request(description, content, required.getOrElse(false)))
+      Request(description, content, required.getOrElse(false))
+    )
 
   implicit def responseDecoder[A: Decoder]: Decoder[Response[A]] =
     Decoder.forProduct3(
@@ -191,8 +197,9 @@ object JsonDecoders {
       (
           description: String,
           headers: Option[Map[String, Either[Header[A], Reference]]],
-          content: Option[Map[String, MediaType[A]]]) =>
-        Response(description, headers.getOrElse(Map.empty), content.getOrElse(Map.empty)))
+          content: Option[Map[String, MediaType[A]]]
+      ) => Response(description, headers.getOrElse(Map.empty), content.getOrElse(Map.empty))
+    )
 
   implicit val locationDecoder: Decoder[Location] = Decoder.decodeString.emap(Location.parse)
 
@@ -212,34 +219,33 @@ object JsonDecoders {
 
   // Avoid forProductXX
   implicit def operationDecoder[A: Decoder]: Decoder[Path.Operation[A]] =
-    Decoder.instance(
-      c =>
-        for {
-          tags         <- c.downField("tags").as[Option[List[String]]]
-          summary      <- c.downField("summary").as[Option[String]]
-          description  <- c.downField("description").as[Option[String]]
-          externalDocs <- c.downField("externalDocs").as[Option[ExternalDocs]]
-          operationId  <- c.downField("operationId").as[Option[String]]
-          parameters   <- c.downField("parameters").as[Option[List[Either[Parameter[A], Reference]]]]
-          requestBody  <- c.downField("requestBody").as[Option[Either[Request[A], Reference]]]
-          responses    <- c.downField("responses").as[Map[String, Either[Response[A], Reference]]]
-          callbacks    <- c.downField("callbacks").as[Option[Map[String, Either[Callback[A], Reference]]]]
-          deprecated   <- c.downField("deprecated").as[Option[Boolean]]
-          servers      <- c.downField("servers").as[Option[List[Server]]]
-        } yield
-          Path.Operation(
-            tags.getOrElse(List.empty),
-            summary,
-            description,
-            externalDocs,
-            operationId,
-            parameters.getOrElse(List.empty),
-            requestBody,
-            responses,
-            callbacks.getOrElse(Map.empty),
-            deprecated.getOrElse(false),
-            servers.getOrElse(List.empty)
-        ))
+    Decoder.instance(c =>
+      for {
+        tags         <- c.downField("tags").as[Option[List[String]]]
+        summary      <- c.downField("summary").as[Option[String]]
+        description  <- c.downField("description").as[Option[String]]
+        externalDocs <- c.downField("externalDocs").as[Option[ExternalDocs]]
+        operationId  <- c.downField("operationId").as[Option[String]]
+        parameters   <- c.downField("parameters").as[Option[List[Either[Parameter[A], Reference]]]]
+        requestBody  <- c.downField("requestBody").as[Option[Either[Request[A], Reference]]]
+        responses    <- c.downField("responses").as[Map[String, Either[Response[A], Reference]]]
+        callbacks    <- c.downField("callbacks").as[Option[Map[String, Either[Callback[A], Reference]]]]
+        deprecated   <- c.downField("deprecated").as[Option[Boolean]]
+        servers      <- c.downField("servers").as[Option[List[Server]]]
+      } yield Path.Operation(
+        tags.getOrElse(List.empty),
+        summary,
+        description,
+        externalDocs,
+        operationId,
+        parameters.getOrElse(List.empty),
+        requestBody,
+        responses,
+        callbacks.getOrElse(Map.empty),
+        deprecated.getOrElse(false),
+        servers.getOrElse(List.empty)
+      )
+    )
 
   implicit def itemObjectDecoder[A: Decoder]: Decoder[Path.ItemObject[A]] =
     Decoder.forProduct13(
@@ -255,7 +261,8 @@ object JsonDecoders {
       "patch",
       "trace",
       "servers",
-      "parameters")(
+      "parameters"
+    )(
       (
           (
               ref: Option[String], // $ref
@@ -285,7 +292,10 @@ object JsonDecoders {
               patch,
               trace,
               servers.getOrElse(List.empty),
-              parameters.getOrElse(List.empty))))
+              parameters.getOrElse(List.empty)
+            )
+        )
+    )
 
   implicit def componentsDecoder[A: Decoder]: Decoder[Components[A]] =
     Decoder.forProduct4(
@@ -298,12 +308,15 @@ object JsonDecoders {
           schemas: Option[Map[String, A]],
           responses: Option[Map[String, Either[Response[A], Reference]]],
           requestBodies: Option[Map[String, Either[Request[A], Reference]]],
-          parameters: Option[Map[String, Either[Parameter[A], Reference]]]) =>
+          parameters: Option[Map[String, Either[Parameter[A], Reference]]]
+      ) =>
         Components(
           schemas.getOrElse(Map.empty),
           responses.getOrElse(Map.empty),
           requestBodies.getOrElse(Map.empty),
-          parameters.getOrElse(Map.empty)))
+          parameters.getOrElse(Map.empty)
+        )
+    )
 
   implicit def openApiDecoder[A: Decoder]: Decoder[OpenApi[A]] =
     Decoder.forProduct7(
@@ -322,7 +335,8 @@ object JsonDecoders {
           paths: Option[Map[String, Path.ItemObject[A]]],
           components: Option[Components[A]],
           tags: Option[List[Tag]],
-          externalDocs: Option[ExternalDocs]) =>
+          externalDocs: Option[ExternalDocs]
+      ) =>
         OpenApi(
           openapi,
           info,
@@ -330,6 +344,8 @@ object JsonDecoders {
           paths.getOrElse(Map.empty),
           components,
           tags.getOrElse(List.empty),
-          externalDocs))
+          externalDocs
+        )
+    )
 
 }

--- a/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/JsonEncoders.scala
@@ -140,7 +140,8 @@ object JsonEncoders {
         p.explode,
         p.allowEmptyValue,
         p.allowReserved,
-        p.schema)
+        p.schema
+      )
     }
 
   // Avoid forProductXX

--- a/src/main/scala/higherkindness/skeuomorph/openapi/ParseOpenApi.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/ParseOpenApi.scala
@@ -36,14 +36,13 @@ object ParseOpenApi {
     new Parser[F, YamlSource, OpenApi[T]] {
       import yaml.{Decoder => _, _}
       override def parse(input: YamlSource)(implicit S: Sync[F]): F[OpenApi[T]] =
-        readContent(input.file).flatMap(
-          x =>
-            S.fromEither(
-              yaml
-                .Decoder[OpenApi[T]]
-                .apply(x)
-                .left
-                .map(_.valueOr(identity))
+        readContent(input.file).flatMap(x =>
+          S.fromEither(
+            yaml
+              .Decoder[OpenApi[T]]
+              .apply(x)
+              .left
+              .map(_.valueOr(identity))
           )
         )
     }

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
@@ -36,8 +36,8 @@ object FieldF {
       position: Int,
       options: List[OptionValue],
       isRepeated: Boolean,
-      isMapField: Boolean)
-      extends FieldF[A] {
+      isMapField: Boolean
+  ) extends FieldF[A] {
     def indices: List[Int] = List(position)
   }
 
@@ -129,7 +129,8 @@ object ProtobufF {
       name: String,
       symbols: List[(String, Int)],
       options: List[OptionValue],
-      aliases: List[(String, Int)]): ProtobufF[A] = TEnum(name, symbols, options, aliases)
+      aliases: List[(String, Int)]
+  ): ProtobufF[A] = TEnum(name, symbols, options, aliases)
   def message[A](
       name: String,
       fields: List[FieldF[A]],
@@ -170,7 +171,8 @@ object ProtobufF {
 
       def makeFieldB(field: FieldF.Field[A]): G[FieldF.Field[B]] =
         f(field.tpe).map(b =>
-          FieldF.Field[B](field.name, b, field.position, field.options, field.isRepeated, field.isMapField))
+          FieldF.Field[B](field.name, b, field.position, field.options, field.isRepeated, field.isMapField)
+        )
 
       def makeOneOfB(oneOf: FieldF.OneOfField[A]): G[FieldF[B]] =
         f(oneOf.tpe).map(b => FieldF.OneOfField[B](oneOf.name, b, oneOf.indices): FieldF[B])

--- a/src/test/scala/higherkindness/skeuomorph/PrinterSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/PrinterSpec.scala
@@ -49,7 +49,8 @@ class PrinterSpec extends Specification with ScalaCheck with Discipline {
 
   val contravariantMonoidalPrinter = checkAll(
     "ContravariantMonoidal[Printer].contravariantMonoidal",
-    ContravariantMonoidalTests[Printer].contravariantMonoidal[MiniInt, MiniInt, MiniInt])
+    ContravariantMonoidalTests[Printer].contravariantMonoidal[MiniInt, MiniInt, MiniInt]
+  )
 
   val monoidPrinter = checkAll("ContravariantMonoidal[Printer].monoid", MonoidTests[Printer[MiniInt]].monoid)
   val semigroupPrinter =

--- a/src/test/scala/higherkindness/skeuomorph/avro/AvroSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/avro/AvroSpec.scala
@@ -60,8 +60,10 @@ class AvroSpec extends Specification with ScalaCheck {
       (sch.getName should_== name)
         .and(sch.getNamespace should_== namespace.getOrElse(""))
         .and(sch.getDoc should_== doc.getOrElse(""))
-        .and(sch.getFields.asScala.toList.map(f => (f.name, f.doc)) should_== fields.map(f =>
-          (f.name, f.doc.getOrElse(""))))
+        .and(
+          sch.getFields.asScala.toList.map(f => (f.name, f.doc)) should_== fields.map(f => (f.name, f.doc.getOrElse(""))
+          )
+        )
 
     case AvroF.TEnum(_, _, _, _, _) => true
     case AvroF.TUnion(_)            => true

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -99,8 +99,11 @@ object instances {
         if (withTNull) Gen.const(MuF.TNull[T]()) else nonNullPrimitives,
         sampleBool
       ).mapN((t1, t2, reversed) =>
-        MuF.TCoproduct(if (reversed) NonEmptyList.of(B.algebra(t2), B.algebra(t1))
-        else NonEmptyList.of(B.algebra(t1), B.algebra(t2))))
+        MuF.TCoproduct(
+          if (reversed) NonEmptyList.of(B.algebra(t2), B.algebra(t1))
+          else NonEmptyList.of(B.algebra(t1), B.algebra(t2))
+        )
+      )
     }
 
   implicit def muArbitrary[T](implicit T: Arbitrary[T]): Arbitrary[MuF[T]] = {
@@ -147,7 +150,8 @@ object instances {
         ).mapN { (n, f, p, c) =>
           MuF.product(n, f, p, c)
         }
-      ))
+      )
+    )
   }
 
   def eitherGen[A, B](left: Gen[A], right: Gen[B]): Gen[Either[A, B]] =
@@ -190,7 +194,8 @@ object instances {
         Gen.option(sampleBool),
         Gen.option(sampleBool),
         Gen.option(sampleBool),
-        T.arbitrary).mapN(Parameter.apply)
+        T.arbitrary
+      ).mapN(Parameter.apply)
 
     val parameters: Gen[List[Either[Parameter[T], Reference]]] = Gen.listOfN(2, eitherGen(parameterGen, referenceGen))
 
@@ -206,7 +211,8 @@ object instances {
         responsesGen,
         Map.empty[String, Either[Callback[T], Reference]].pure[Gen],
         sampleBool,
-        serversGen).mapN(Path.Operation.apply)
+        serversGen
+      ).mapN(Path.Operation.apply)
 
     val itemObjectsGen: Gen[Path.ItemObject[T]] =
       (
@@ -230,8 +236,8 @@ object instances {
         mapStringToGen(T.arbitrary),
         responsesGen,
         mapStringToGen(eitherGen(requestGen, referenceGen)),
-        mapStringToGen(eitherGen(parameterGen, referenceGen)))
-        .mapN(Components.apply)
+        mapStringToGen(eitherGen(parameterGen, referenceGen))
+      ).mapN(Components.apply)
 
     Arbitrary(
       (
@@ -241,8 +247,9 @@ object instances {
         mapStringToGen(itemObjectsGen),
         Gen.option(componentsGen),
         Gen.listOfN(5, tagGen),
-        Gen.option(externalDocsGen))
-        .mapN(OpenApi[T]))
+        Gen.option(externalDocsGen)
+      ).mapN(OpenApi[T])
+    )
   }
 
   implicit def jsonSchemaFOpenApiArbitrary: Arbitrary[JsonSchemaF.Fixed] = {
@@ -355,7 +362,8 @@ object instances {
           Gen.listOf(nonEmptyString),
           Gen.posNum[Int]
         ).mapN(AvroF.fixed[T])
-      ))
+      )
+    )
   }
 
   def protobufFMessage[T](implicit T: Arbitrary[T]): Gen[ProtobufF.TMessage[T]] = {

--- a/src/test/scala/higherkindness/skeuomorph/mu/comparison/ComparisonSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/mu/comparison/ComparisonSpec.scala
@@ -69,7 +69,8 @@ class ComparisonSpec extends Specification {
       Path.empty -> List(
         PromotionToCoproduct(extended),
         NumericWidening(original, long[T].embed)
-      ))
+      )
+    )
   }
 
   def optionToEither = {
@@ -132,7 +133,8 @@ class ComparisonSpec extends Specification {
       "foo",
       List(Field("name", string[T].embed, List(1)), Field("age", option(int[T].embed).embed, List(2))),
       Nil,
-      Nil).embed
+      Nil
+    ).embed
 
     Comparison(original, promoted) must_== Match(Path.empty / Name("foo") / FieldName("age"), PromotionToOption[T]())
   }
@@ -145,21 +147,26 @@ class ComparisonSpec extends Specification {
       "foo",
       List(
         Field("name", string[T].embed, List(1)),
-        Field("age", either(int[T].embed, boolean[T].embed).embed, List(2))),
+        Field("age", either(int[T].embed, boolean[T].embed).embed, List(2))
+      ),
       Nil,
-      Nil).embed
+      Nil
+    ).embed
     val promotedR = product(
       "foo",
       List(Field("name", either(long[T].embed, string[T].embed).embed, List(1)), Field("age", int[T].embed, List(2))),
       Nil,
-      Nil).embed
+      Nil
+    ).embed
 
     Comparison(original, promotedL) must_== Match(
       Path.empty / Name("foo") / FieldName("age"),
-      PromotionToEither(either(int[T].embed, boolean[T].embed).embed))
+      PromotionToEither(either(int[T].embed, boolean[T].embed).embed)
+    )
     Comparison(original, promotedR) must_== Match(
       Path.empty / Name("foo") / FieldName("name"),
-      PromotionToEither(either(long[T].embed, string[T].embed).embed))
+      PromotionToEither(either(long[T].embed, string[T].embed).embed)
+    )
 
   }
 
@@ -173,16 +180,15 @@ class ComparisonSpec extends Specification {
     val extended = product(
       "foo",
       List(Field("name", string[T].embed, List(1))),
-      List(product(
-        "bar",
-        List(Field("first", string[T].embed, List(1)), Field("second", int[T].embed, List(1))),
-        Nil,
-        Nil).embed),
+      List(
+        product("bar", List(Field("first", string[T].embed, List(1)), Field("second", int[T].embed, List(1))), Nil, Nil).embed
+      ),
       Nil
     ).embed
 
     Comparison(original, extended) must_== Match(
       Path.empty / Name("foo") / Name("bar") / FieldName("second"),
-      Addition(int[T].embed))
+      Addition(int[T].embed)
+    )
   }
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaDecoderSpecification.scala
@@ -86,7 +86,8 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
         "enum" -> Json.arr(
           Json.fromString("green"),
           Json.fromString("blue")
-        ))
+        )
+      )
       decoder.decodeJson(enumType) must beRight(Fixed.enum(List("green", "blue")))
     }
     "when sum object is provided" >> {
@@ -97,7 +98,8 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
         )
       )
       decoder.decodeJson(sumType) must beRight(
-        Fixed.sum(List(Fixed.reference("#/components/schemas/Cat"), Fixed.reference("#/components/schemas/Dog"))))
+        Fixed.sum(List(Fixed.reference("#/components/schemas/Cat"), Fixed.reference("#/components/schemas/Dog")))
+      )
     }
     "when array object is provided" >> {
       val arrayType = Json.obj(
@@ -117,7 +119,8 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
           "age" -> Json.obj(
             "type"    -> Json.fromString("integer"),
             "format"  -> Json.fromString("int32"),
-            "minimum" -> Json.fromInt(0)),
+            "minimum" -> Json.fromInt(0)
+          ),
           "address" -> Json.obj(s"$$ref" -> Json.fromString("#/components/schemas/Address"))
         ),
         "required" -> Json.arr(Json.fromString("name"))
@@ -126,7 +129,8 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
         obj(
           "name"    -> Fixed.string(),
           "age"     -> Fixed.integer(),
-          "address" -> Fixed.reference("#/components/schemas/Address"))("name")
+          "address" -> Fixed.reference("#/components/schemas/Address")
+        )("name")
       )
     }
 
@@ -145,7 +149,9 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
         .decodeJson(
           Json.obj(
             "type"                 -> Json.fromString("object"),
-            "additionalProperties" -> Json.obj("type" -> Json.fromString("object")))) must beRight(obj()())
+            "additionalProperties" -> Json.obj("type" -> Json.fromString("object"))
+          )
+        ) must beRight(obj()())
     }
 
     "when object does have type" >> {
@@ -160,7 +166,8 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
             )
           ),
           "required" -> Json.arr(Json.fromString("subscriptionId"))
-        )) must beRight(obj("subscriptionId" -> Fixed.string())("subscriptionId"))
+        )
+      ) must beRight(obj("subscriptionId" -> Fixed.string())("subscriptionId"))
     }
 
   }
@@ -168,16 +175,19 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
   "Decoder[JsonSchemaF.Fixed] should not able to decode" >> {
     "when the type is not valid" >> {
       decoder.decodeJson(Json.obj("type" -> Json.fromString("foo"))).leftMap(_.message) must beLeft(
-        "foo is not well formed type")
+        "foo is not well formed type"
+      )
     }
     "when it is not valid schema" >> {
       decoder.decodeJson(Json.fromString("string")).leftMap(_.message) must beLeft(
-        "Attempt to decode value on failed cursor")
+        "Attempt to decode value on failed cursor"
+      )
     }
 
     "when array does not have values" >> {
       decoder.decodeJson(Json.obj("type" -> Json.fromString("array"))).leftMap(_.message) must beLeft(
-        "array is not well formed type")
+        "array is not well formed type"
+      )
     }
 
   }
@@ -186,7 +196,8 @@ class JsonSchemaDecoderSpecification extends org.specs2.mutable.Specification {
     format.fold(
       Json
         .obj(
-          "type"                -> Json.fromString(tpe)
-        ))(x => Json.obj("type" -> Json.fromString(tpe), "format" -> Json.fromString(x)))
+          "type" -> Json.fromString(tpe)
+        )
+    )(x => Json.obj("type" -> Json.fromString(tpe), "format" -> Json.fromString(x)))
 
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/JsonSchemaPrintSpecification.scala
@@ -72,9 +72,11 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
                 "name"    -> Fixed.string(),
                 "surname" -> Fixed.string(),
                 "age"     -> Fixed.integer(),
-                "email"   -> Fixed.string()),
-              List("name", "surname"))) must ===(
-        s"""|final case class Person(name: String, surname: String, age: Option[Int], email: Option[String])
+                "email"   -> Fixed.string()
+              ),
+              List("name", "surname")
+            )
+        ) must ===(s"""|final case class Person(name: String, surname: String, age: Option[Int], email: Option[String])
             |object Person {
             |
             |
@@ -85,8 +87,8 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
       schemaWithName
         .print(
           "=>" ->
-            Fixed.`object`(List("name" -> Fixed.string()), List("name"))) must ===(
-        s"""|final case class `=>`(name: String)
+            Fixed.`object`(List("name" -> Fixed.string()), List("name"))
+        ) must ===(s"""|final case class `=>`(name: String)
             |object `=>` {
             |
             |
@@ -97,8 +99,8 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
       schemaWithName
         .print(
           "Person" -> Fixed
-            .`object`(List("age" -> Fixed.integer(), "email" -> Fixed.string()), List("name", "surname"))) must ===(
-        s"""|final case class Person(age: Option[Int], email: Option[String])
+            .`object`(List("age" -> Fixed.integer(), "email" -> Fixed.string()), List("name", "surname"))
+        ) must ===(s"""|final case class Person(age: Option[Int], email: Option[String])
             |object Person {
             |
             |
@@ -114,7 +116,9 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
                 "name"    -> Fixed.string(),
                 "surname" -> Fixed.string()
               ),
-              List("name", "surname"))) must ===(s"""|final case class Person(name: String, surname: String)
+              List("name", "surname")
+            )
+        ) must ===(s"""|final case class Person(name: String, surname: String)
                                                    |object Person {
                                                    |
                                                    |
@@ -130,7 +134,9 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
                 "name" -> Fixed.string(),
                 "type" -> Fixed.string()
               ),
-              List("name", "type"))) must ===(s"""|final case class Person(name: String, `type`: String)
+              List("name", "type")
+            )
+        ) must ===(s"""|final case class Person(name: String, `type`: String)
                                                    |object Person {
                                                    |
                                                    |
@@ -153,8 +159,9 @@ class JsonSchemaPrintSpecification extends org.specs2.mutable.Specification {
     "when sum is provided" >> {
       schemaWithName
         .print(
-          "Pet" -> Fixed.sum(
-            List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat")))) must
+          "Pet" -> Fixed
+            .sum(List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat")))
+        ) must
         ===("""|type Pet = Dog :+: Cat :+: CNil
                |object Pet {
                |

--- a/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/NestedObjectSpecification.scala
@@ -44,14 +44,16 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
     "when an array is provided in the first level" >> {
       val nestedObject = obj("foo" -> Fixed.string())("foo")
       nestedTypesFrom(Fixed.array(nestedObject)) must ===(
-        expectedTypes("AnonymousObject" -> nestedObject)(Fixed.array(Fixed.reference("AnonymousObject"))))
+        expectedTypes("AnonymousObject" -> nestedObject)(Fixed.array(Fixed.reference("AnonymousObject")))
+      )
     }
 
     "when an object is nested inside another object " >> {
       val nestedObject = obj("name" -> Fixed.string(), "password" -> Fixed.password())("name")
       nestedTypesFrom(obj("user" -> nestedObject, "another" -> Fixed.binary())("user")) must ===(
         expectedTypes("User"     -> nestedObject)(
-          obj("user" -> Fixed.reference("User"), "another" -> Fixed.binary())("user"))
+          obj("user" -> Fixed.reference("User"), "another" -> Fixed.binary())("user")
+        )
       )
     }
 
@@ -59,7 +61,9 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
       val nestedObject = obj("foo" -> Fixed.string())("foo")
       nestedTypesFrom(obj("foo"         -> Fixed.array(nestedObject))()) must ===(
         expectedTypes("AnonymousObject" -> nestedObject)(
-          obj("foo" -> Fixed.array(Fixed.reference("AnonymousObject")))()))
+          obj("foo" -> Fixed.array(Fixed.reference("AnonymousObject")))()
+        )
+      )
     }
 
     "when an enum is nested inside an object" >> {
@@ -89,29 +93,44 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
           "foo1" ->
             obj(
               "foo2" ->
-                obj("foo3" ->
-                  obj("foo4" ->
-                    obj("foo5" -> Fixed.string())())())())())()) must ===(
+                obj(
+                  "foo3" ->
+                    obj(
+                      "foo4" ->
+                        obj("foo5" -> Fixed.string())()
+                    )()
+                )()
+            )()
+        )()
+      ) must ===(
         expectedTypes(
           "Foo4" -> obj("foo5" -> Fixed.string())(),
           "Foo3" -> obj("foo4" -> Fixed.reference("Foo4"))(),
           "Foo2" -> obj("foo3" -> Fixed.reference("Foo3"))(),
           "Foo1" -> obj("foo2" -> Fixed.reference("Foo2"))()
-        )(obj("foo1" -> Fixed.reference("Foo1"))()))
+        )(obj("foo1" -> Fixed.reference("Foo1"))())
+      )
     }
 
     "when there are multiple level of nested objects when than alpha characters are the same" >> {
       nestedTypesFrom(
         obj(
           "foo" ->
-            obj("foo1" ->
-              obj("foo" ->
-                obj("foo" -> Fixed.string())())())())()) must ===(
+            obj(
+              "foo1" ->
+                obj(
+                  "foo" ->
+                    obj("foo" -> Fixed.string())()
+                )()
+            )()
+        )()
+      ) must ===(
         expectedTypes(
           "Foo"  -> obj("foo"  -> Fixed.string())(),
           "Foo1" -> obj("foo"  -> Fixed.reference("Foo"))(),
           "Foo2" -> obj("foo1" -> Fixed.reference("Foo1"))()
-        )(obj("foo" -> Fixed.reference("Foo2"))()))
+        )(obj("foo" -> Fixed.reference("Foo2"))())
+      )
     }
 
     "when there are multiple level of nested object of different types" >> {
@@ -119,16 +138,30 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
         obj(
           "foo1" ->
             Fixed.array(
-              obj("foo2" ->
-                Fixed.array(obj("foo3" ->
-                  Fixed.array(obj("foo4" ->
-                    Fixed.array(obj("foo5" -> Fixed.array(Fixed.string()))()))()))()))()))()) must ===(
+              obj(
+                "foo2" ->
+                  Fixed.array(
+                    obj(
+                      "foo3" ->
+                        Fixed.array(
+                          obj(
+                            "foo4" ->
+                              Fixed.array(obj("foo5" -> Fixed.array(Fixed.string()))())
+                          )()
+                        )
+                    )()
+                  )
+              )()
+            )
+        )()
+      ) must ===(
         expectedTypes(
           "AnonymousObject3" -> obj("foo2" -> Fixed.array(Fixed.reference("AnonymousObject2")))(),
           "AnonymousObject2" -> obj("foo3" -> Fixed.array(Fixed.reference("AnonymousObject1")))(),
           "AnonymousObject1" -> obj("foo4" -> Fixed.array(Fixed.reference("AnonymousObject")))(),
           "AnonymousObject"  -> obj("foo5" -> Fixed.array(Fixed.string()))()
-        )(obj("foo1" -> Fixed.array(Fixed.reference("AnonymousObject3")))()))
+        )(obj("foo1" -> Fixed.array(Fixed.reference("AnonymousObject3")))())
+      )
     }
   }
   "when the name of the anonymous object exists already as a type" >> {
@@ -139,7 +172,8 @@ class NestedObjectSpecification extends org.specs2.mutable.Specification {
       expectedTypes(
         "User"  -> Fixed.string(),
         "User1" -> obj("name" -> Fixed.string())()
-      )(obj("user" -> Fixed.reference("User1"))()))
+      )(obj("user" -> Fixed.reference("User1"))())
+    )
 
   }
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiDecoderSpecification.scala
@@ -45,7 +45,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
           }""")
 
       Decoder[Info].decodeJson(json) must beRight(
-        Info("Sample Pet Store App", "This is a sample server for a pet store.".some, "1.0.1"))
+        Info("Sample Pet Store App", "This is a sample server for a pet store.".some, "1.0.1")
+      )
     }
   }
 
@@ -60,7 +61,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
       }
       """)
       Decoder[Header[JsonSchemaF.Fixed]].decodeJson(json) must beRight(
-        Header[JsonSchemaF.Fixed]("The number of allowed requests in the current period", Fixed.integer()))
+        Header[JsonSchemaF.Fixed]("The number of allowed requests in the current period", Fixed.integer())
+      )
     }
 
   }
@@ -87,7 +89,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
       }
       """)
       Decoder[ExternalDocs].decodeJson(json) must beRight(
-        ExternalDocs("https://example.com", "Find more info here".some))
+        ExternalDocs("https://example.com", "Find more info here".some)
+      )
     }
 
   }
@@ -137,13 +140,15 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
             request("application/json" -> mediaType(Fixed.reference("#/components/schemas/SomePayload"))).optional
               .withDescription("Callback payload"),
             responses = "200" -> response("webhook successfully processed and no retries will be performed")
-          ))
+          )
+        )
 
       Decoder[Callback[JsonSchemaF.Fixed]].decodeJson(json) should beRight(
         Callback(
           "http://notificationServer.com?transactionId={$request.body#/id}&email={$request.body#/email}" ->
             itemObject
-        ))
+        )
+      )
     }
   }
 
@@ -187,14 +192,16 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
             "skip",
             JsonSchemaF.Fixed.integer(),
             required = true,
-            description = "number of items to skip".some).asLeft,
+            description = "number of items to skip".some
+          ).asLeft,
           "limitParam" -> query(
             "limit",
             JsonSchemaF.Fixed.integer(),
             required = true,
             description = "max records to return".some
           ).asLeft
-        ))
+        )
+        )
       )
 
     }
@@ -242,7 +249,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
     "when a valid object is provided" >> {
       val json = unsafeParse("{}")
       Decoder[Encoding[JsonSchemaF.Fixed]].decodeJson(json) must beRight(
-        Encoding[JsonSchemaF.Fixed](None, Map.empty, None, None, None))
+        Encoding[JsonSchemaF.Fixed](None, Map.empty, None, None, None)
+      )
     }
   }
 
@@ -256,7 +264,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
       )
 
       Decoder[Server].decodeJson(json) must beRight(
-        Server("https://development.gigantic-server.com/v1", "Development server".some, Map.empty))
+        Server("https://development.gigantic-server.com/v1", "Development server".some, Map.empty)
+      )
     }
 
     "when is valid and variables are provided" >> {
@@ -291,11 +300,13 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
             "username" -> Server.Variable(
               List.empty,
               "demo",
-              """this value is assigned by the service provider, in this example `gigantic-server.com`""".some),
+              """this value is assigned by the service provider, in this example `gigantic-server.com`""".some
+            ),
             "port"     -> Server.Variable(List("8443", "443"), "8443", None),
             "basePath" -> Server.Variable(List.empty, "v2", None)
           )
-        ))
+        )
+      )
     }
   }
   "Open api object should be able to decode" >> {
@@ -319,7 +330,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
           None,
           List.empty,
           None
-        ))
+        )
+      )
     }
 
     "when paths are provided" >> {
@@ -346,7 +358,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
           None,
           List.empty,
           None
-        ))
+        )
+      )
     }
   }
 
@@ -385,7 +398,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
           name = "limit",
           description = "How many items to return at one time (max 100)".some,
           allowEmptyValue = false,
-          schema = Fixed.integer())
+          schema = Fixed.integer()
+        )
       )
     }
 
@@ -414,7 +428,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
           required = true,
           style = "simple",
           schema = Fixed.array(Fixed.long())
-        ))
+        )
+      )
     }
 
     "when cookie object is provided" >> {
@@ -431,7 +446,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
           name = "csrftoken",
           description = None,
           schema = Fixed.string()
-        ))
+        )
+      )
     }
 
   }
@@ -458,7 +474,9 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
 
       Decoder[Path.ItemObject[JsonSchemaF.Fixed]].decodeJson(json) must beRight(
         emptyItemObject[JsonSchemaF.Fixed].withParameter(
-          path("id", JsonSchemaF.Fixed.array(JsonSchemaF.Fixed.string()), description = "ID of pet to use".some)))
+          path("id", JsonSchemaF.Fixed.array(JsonSchemaF.Fixed.string()), description = "ID of pet to use".some)
+        )
+      )
     }
 
     "when get operation is defined" >> {
@@ -544,7 +562,8 @@ class OpenApiDecoderSpecification extends org.specs2.mutable.Specification {
                   obj(
                     "name"   -> Fixed.string(),
                     "status" -> Fixed.string()
-                  )("status"))
+                  )("status")
+                )
           ).optional,
           "200" -> response("Pet updated.", expectedResponseContent: _*),
           "405" -> response("Method Not Allowed", expectedResponseContent: _*)

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiNestedObjectSpecification.scala
@@ -27,7 +27,8 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
       extractNestedTypes(
         openApi("name")
           .withSchema("Foo", obj("bar" -> obj("x" -> Fixed.string())())())
-          .withSchema("Foos", Fixed.array(obj("y" -> Fixed.integer())()))) must ===(
+          .withSchema("Foos", Fixed.array(obj("y" -> Fixed.integer())()))
+      ) must ===(
         openApi("name")
           .withSchema("Bar", obj("x" -> Fixed.string)())
           .withSchema("Foo", obj("bar" -> Fixed.reference("Bar"))())
@@ -44,15 +45,22 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
               operation[JsonSchemaF.Fixed](
                 request("application/json" -> mediaType(obj("foo" -> Fixed.enum(List("1", "2")))())),
                 "200" -> response[JsonSchemaF.Fixed]("Null response")
-              )))) must ===(
+              )
+            )
+        )
+      ) must ===(
         openApi("name")
           .withPath(
             "foo" -> emptyItemObject
-              .withPut(operation[JsonSchemaF.Fixed](
-                request("application/json" -> mediaType(obj("foo" -> Fixed.reference("Foo"))())),
-                "200" -> response[JsonSchemaF.Fixed]("Null response")
-              )))
-          .withSchema("Foo", Fixed.enum(List("1", "2"))))
+              .withPut(
+                operation[JsonSchemaF.Fixed](
+                  request("application/json" -> mediaType(obj("foo" -> Fixed.reference("Foo"))())),
+                  "200" -> response[JsonSchemaF.Fixed]("Null response")
+                )
+              )
+          )
+          .withSchema("Foo", Fixed.enum(List("1", "2")))
+      )
     }
 
     "when nested objects are defined in request" >> {
@@ -63,16 +71,24 @@ class OpenApiNestedObjectSpecification extends org.specs2.mutable.Specification 
               operationWithResponses[JsonSchemaF.Fixed](
                 "200" -> response[JsonSchemaF.Fixed](
                   "Response",
-                  "application/json" -> mediaType(obj("values" -> Fixed.array(obj("value" -> Fixed.integer())()))()))
-              )))) must ===(
+                  "application/json" -> mediaType(obj("values" -> Fixed.array(obj("value" -> Fixed.integer())()))())
+                )
+              )
+            )
+        )
+      ) must ===(
         openApi("name")
           .withPath(
             "foo" -> emptyItemObject
               .withGet(
-                operationWithResponses[JsonSchemaF.Fixed]("200" -> response[JsonSchemaF.Fixed](
-                  "Response",
-                  "application/json" -> mediaType(obj("values" -> Fixed.array(Fixed.reference("AnonymousObject")))())))
-              ))
+                operationWithResponses[JsonSchemaF.Fixed](
+                  "200" -> response[JsonSchemaF.Fixed](
+                    "Response",
+                    "application/json" -> mediaType(obj("values" -> Fixed.array(Fixed.reference("AnonymousObject")))())
+                  )
+                )
+              )
+          )
           .withSchema("AnonymousObject", obj("value" -> Fixed.integer())())
       )
     }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -66,8 +66,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       import client.http4s.circe._
       model.print(
         petstoreOpenApi
-          .withSchema("212bar_Foo-X1", obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())) must ===(
-        s"""|object models {
+          .withSchema("212bar_Foo-X1", obj("1fo_o" -> Fixed.string(), "ba-r" -> Fixed.integer())())
+      ) must ===(s"""|object models {
             |$modelImports
             |final case class `212bar_Foo-X1`(`1fo_o`: Option[String], `ba-r`: Option[Int])
             |object `212bar_Foo-X1` {
@@ -94,7 +94,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
         petstoreOpenApi.withSchema(
           "Bars",
           Fixed.array(Fixed.reference("#/components/schemas/Bar"))
-        )) must ===(s"""|object models {
+        )
+      ) must ===(s"""|object models {
               |$modelImports
               |type Bars = List[Bar]
               |}""".stripMargin)
@@ -106,7 +107,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
         petstoreOpenApi.withSchema(
           "bar_Foo-X1s",
           Fixed.array(Fixed.reference("#/components/schemas/bar_Foo-X1"))
-        )) must ===(s"""|object models {
+        )
+      ) must ===(s"""|object models {
               |$modelImports
               |type `bar_Foo-X1s` = List[`bar_Foo-X1`]
               |}""".stripMargin)
@@ -189,10 +191,12 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
     "when a sum type is provided" >> {
 
       import client.http4s.circe._
-      model.print(petstoreOpenApi.withSchema(
-        "Pet",
-        Fixed.sum(List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat"))))) must ===(
-        s"""|object models {
+      model.print(
+        petstoreOpenApi.withSchema(
+          "Pet",
+          Fixed.sum(List(Fixed.reference("#/components/schemas/Dog"), Fixed.reference("#/components/schemas/Cat")))
+        )
+      ) must ===(s"""|object models {
             |$modelImports
             |import Pet._
             |type Pet = Dog :+: Cat :+: CNil
@@ -230,9 +234,9 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       model.print(
         petstoreOpenApi.withSchema(
           "1-Pet",
-          Fixed.sum(List(
-            Fixed.reference("#/components/schemas/2-Dog"),
-            Fixed.reference("#/components/schemas/3-Cat"))))) must ===(s"""|object models {
+          Fixed.sum(List(Fixed.reference("#/components/schemas/2-Dog"), Fixed.reference("#/components/schemas/3-Cat")))
+        )
+      ) must ===(s"""|object models {
             |$modelImports
             |import `1-Pet`._
             |type `1-Pet` = `2-Dog` :+: `3-Cat` :+: CNil
@@ -272,7 +276,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           .withSchema(
             "Bars",
             Fixed.array(Fixed.reference("#/components/schemas/Bar"))
-          )) must ===(s"""|object models {
+          )
+      ) must ===(s"""|object models {
                           |$modelImports
                           |final case class Bar(foo: String)
                           |object Bar {
@@ -306,7 +311,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when a put and delete are provided" >> {
@@ -327,7 +333,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when get endpoints are provided" >> {
@@ -348,7 +355,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when optional body and not optional query parameters are provided" >> {
@@ -437,7 +445,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when there are multiple responses with a default one" >> {
@@ -456,7 +465,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  type GetPayloadErrorResponse = GetPayloadUnexpectedErrorResponse
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when there are multiple responses with not found response" >> {
@@ -700,7 +710,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  type DeletePayloadsErrorResponse = DeletePayloadsNotFoundError
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when multiple failure response are empty" >> {
@@ -720,7 +731,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  type DeletePayloadsErrorResponse = DeletePayloadsNotFoundError :+: DeletePayloadsUnexpectedErrorResponse :+: CNil
            |
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when a post operation is provided and operation id is not provided" >> {
@@ -733,23 +745,27 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
                 request("application/json" -> mediaType(Fixed.reference("#/components/schemas/NewPet"))),
                 responses = "200"          -> response("Null response")
               )
-            ))
+            )
+          )
           .withPath(
             "/pets/{id}" -> emptyItemObject.withPut(
               operation[JsonSchemaF.Fixed](
                 request("application/json" -> mediaType(Fixed.reference("#/components/schemas/UpdatePet"))),
                 responses = "201"          -> response("Null response")
               ).withParameter(path("id", Fixed.string()))
-            ))
+            )
+          )
           .withPath(
             "/pets/{id}/owners/" -> emptyItemObject.withGet(
               operation[JsonSchemaF.Fixed](
                 request(),
                 responses = "201" -> response(
                   "Null response",
-                  "application/json" -> mediaType(Fixed.reference("#/components/schemas/Owners")))
+                  "application/json" -> mediaType(Fixed.reference("#/components/schemas/Owners"))
+                )
               ).withParameter(path("id", Fixed.string()))
-            ))
+            )
+          )
       ) must ===("""|import models._
                     |import shapeless.{:+:, CNil}
                     |trait PetstoreClient[F[_]] {
@@ -803,7 +819,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    def updatePayload(id: String, updatePayload: UpdatePayload): F[Unit] = client.expect[Unit](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show).with(updatePayload))
            |  }
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when get endpoints are provided" >> {
@@ -881,7 +898,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    }
            |  }
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when there are multiple responses with not found response" >> {
@@ -909,7 +927,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
           |    def updateAnotherPayload(id: String, updateAnotherPayloadRequest: UpdateAnotherPayloadRequest): F[UpdatedPayload] = client.expect[UpdatedPayload](Request[F](method = Method.PUT, uri = baseUrl / "payloads" / id.show).with(updateAnotherPayloadRequest))
           |  }
           |
-          |}""".stripMargin)
+          |}""".stripMargin
+      )
     }
 
     "when multiple responses with anonymous objects with default response" >> {
@@ -925,7 +944,8 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |    }
            |  }
            |
-           |}""".stripMargin)
+           |}""".stripMargin
+      )
     }
 
     "when multiple responses and multiple error scenarios" >> {
@@ -1154,7 +1174,8 @@ object OpenApiPrintSpecification {
         request("application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads"))),
         responses = "200" -> response(
           "",
-          "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
+          "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads"))
+        )
       ).withOperationId("updatePayloads")
     )
 
@@ -1163,18 +1184,21 @@ object OpenApiPrintSpecification {
       operation[JsonSchemaF.Fixed](
         request("application/json" -> mediaType(Fixed.reference("#/components/schemas/UpdatePayload"))),
         successNull
-      ).withOperationId("updatePayload").withParameter(pathId))
+      ).withOperationId("updatePayload").withParameter(pathId)
+    )
     .withDelete(
       operation[JsonSchemaF.Fixed](
         request(),
         successNull
-      ).withOperationId("deletePayload").withParameter(pathId))
+      ).withOperationId("deletePayload").withParameter(pathId)
+    )
 
   val mediaTypeReferenceGet = payloadPath -> emptyItemObject.withGet(
     operationWithResponses[JsonSchemaF.Fixed](
       responses = "200" -> response(
         "",
-        "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
+        "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads"))
+      )
     ).withOperationId("getPayload")
       .withParameter(query("limit", Fixed.integer()))
       .withParameter(query("name", Fixed.string()))
@@ -1186,7 +1210,8 @@ object OpenApiPrintSpecification {
       operationWithResponses[JsonSchemaF.Fixed](
         responses = "200" -> response(
           "",
-          "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads")))
+          "application/json" -> mediaType(Fixed.reference("#/components/schemas/Payloads"))
+        )
       ).withOperationId("getPayload")
         .withParameter(path("id", JsonSchemaF.Fixed.string()))
         .withParameter(Reference("#/components/parameters/initParam"))
@@ -1206,7 +1231,8 @@ object OpenApiPrintSpecification {
     .withGet(
       operationWithResponses[JsonSchemaF.Fixed](successPayload)
         .withOperationId("getPayload")
-        .withParameter(path("id", Fixed.string())))
+        .withParameter(path("id", Fixed.string()))
+    )
 
   val mediaTypeOptionBody = payloadPathId -> emptyItemObject
     .withDelete(
@@ -1215,14 +1241,16 @@ object OpenApiPrintSpecification {
         successNull
       ).withOperationId("deletePayload")
         .withParameter(path("id", Fixed.string()))
-        .withParameter(query("size", Fixed.long(), required = true)))
+        .withParameter(query("size", Fixed.long(), required = true))
+    )
 
   val references = payloadPath -> emptyItemObject
     .withPut(
       operationWithReferences[JsonSchemaF.Fixed](
         reference("#/components/schemas/UpdatePayload"),
         responses = "200" -> reference("#/components/schemas/UpdatedPayload")
-      ).withOperationId("updatePayload"))
+      ).withOperationId("updatePayload")
+    )
 
   val multipleResponsesWithDefaultOne = payloadPathId -> emptyItemObject
     .withGet(
@@ -1237,7 +1265,8 @@ object OpenApiPrintSpecification {
       operationWithResponses[JsonSchemaF.Fixed](
         responses = successPayload,
         notFound
-      ).withOperationId("getPayload").withParameter(path("id", Fixed.string())))
+      ).withOperationId("getPayload").withParameter(path("id", Fixed.string()))
+    )
 
   val multipleResponsesWithAnonymousObject = payloadPathId -> emptyItemObject
     .withPut(

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiSchemaSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiSchemaSpec.scala
@@ -43,7 +43,8 @@ class OpenApiSchemaSpec extends Specification with ScalaCheck with Discipline {
   val traverse =
     checkAll(
       "Traverse[JsonSchemaF]",
-      TraverseTests[JsonSchemaF].traverse[MiniInt, MiniInt, MiniInt, Set[MiniInt], Option, Option])
+      TraverseTests[JsonSchemaF].traverse[MiniInt, MiniInt, MiniInt, Set[MiniInt], Option, Option]
+    )
   val functor  = checkAll("Functor[JsonSchemaF]", FunctorTests[JsonSchemaF].functor[MiniInt, MiniInt, String])
   val foldable = checkAll("Foldable[JsonSchemaF]", FoldableTests[JsonSchemaF].foldable[MiniInt, MiniInt])
 
@@ -88,6 +89,8 @@ object Spec {
     Arbitrary(
       eitherGen(
         examplesArbitrary(x => s"/openapi/yaml/$x.yaml")(identity),
-        examplesArbitrary(x => s"/openapi/json/$x.json")(helpers.unsafeParse)))
+        examplesArbitrary(x => s"/openapi/json/$x.json")(helpers.unsafeParse)
+      )
+    )
 
 }

--- a/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/helpers.scala
@@ -40,7 +40,8 @@ object helpers {
 
   private def operationFrom[A](
       requestBody: Option[Either[Request[A], Reference]],
-      responses: Map[String, Either[Response[A], Reference]]): Path.Operation[A] =
+      responses: Map[String, Either[Response[A], Reference]]
+  ): Path.Operation[A] =
     Path.Operation[A](
       tags = List.empty,
       summary = None,
@@ -83,7 +84,8 @@ object helpers {
       name: String,
       schema: A,
       description: Option[String] = None,
-      required: Boolean = true): Parameter.Header[A] =
+      required: Boolean = true
+  ): Parameter.Header[A] =
     Parameter.Header(name, description, schema = schema, required = required)
 
   def path[A](name: String, schema: A, description: Option[String] = None): Parameter[A] =
@@ -93,13 +95,15 @@ object helpers {
       schema: A,
       allowEmptyValue: Boolean = false,
       required: Boolean = false,
-      description: Option[String] = None): Parameter[A] =
+      description: Option[String] = None
+  ): Parameter[A] =
     Parameter.Query(
       name = name,
       description = description,
       allowEmptyValue = allowEmptyValue,
       schema = schema,
-      required = required)
+      required = required
+    )
 
   def noneMediaType[A] = MediaType[A](schema = None, encoding = Map.empty)
 

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -95,7 +95,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |
       |object book {
       |
-      |@message final case class Book(
+      |final case class Book(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) title: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(3) author: _root_.scala.List[_root_.com.acme.author.Author],
@@ -105,17 +105,17 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(16) `type`: _root_.scala.Option[_root_.com.acme.book.`type`],
       |  @_root_.pbdirect.pbIndex(17) nearest_copy: _root_.scala.Option[_root_.com.acme.book.BookStore.Location]
       |)
-      |@message final case class `type`(
+      |final case class `type`(
       |  @_root_.pbdirect.pbIndex(1) foo: _root_.scala.Long,
       |  @_root_.pbdirect.pbIndex(2) thing: _root_.scala.Option[_root_.com.acme.`hyphenated-name`.Thing]
       |)
-      |@message final case class GetBookRequest(
+      |final case class GetBookRequest(
       |  @_root_.pbdirect.pbIndex(1) isbn: _root_.scala.Long
       |)
-      |@message final case class GetBookViaAuthor(
+      |final case class GetBookViaAuthor(
       |  @_root_.pbdirect.pbIndex(1) author: _root_.scala.Option[_root_.com.acme.author.Author]
       |)
-      |@message final case class BookStore(
+      |final case class BookStore(
       |  @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |  @_root_.pbdirect.pbIndex(2) books: _root_.scala.Predef.Map[_root_.scala.Long, _root_.java.lang.String],
       |  @_root_.pbdirect.pbIndex(3) genres: _root_.scala.List[_root_.com.acme.book.Genre],
@@ -125,12 +125,12 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
       |  @_root_.pbdirect.pbIndex(11) coffee_quality: _root_.scala.Option[_root_.com.acme.book.BookStore.CoffeeQuality]
       |)
       |object BookStore {
-      |  @message final case class Location(
+      |  final case class Location(
       |    @_root_.pbdirect.pbIndex(1) town: _root_.java.lang.String,
       |    @_root_.pbdirect.pbIndex(2) country: _root_.scala.Option[_root_.com.acme.book.BookStore.Location.Country]
       |  )
       |  object Location {
-      |    @message final case class Country(
+      |    final case class Country(
       |      @_root_.pbdirect.pbIndex(1) name: _root_.java.lang.String,
       |      @_root_.pbdirect.pbIndex(2) iso_code: _root_.java.lang.String
       |    )
@@ -218,7 +218,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |import _root_.higherkindness.mu.rpc.protocol._
     |
     |object trace {
-    |  @message final case class Span(
+    |  final case class Span(
     |    @_root_.pbdirect.pbIndex(1) trace_id: _root_.scala.Array[Byte],
     |    @_root_.pbdirect.pbIndex(2) span_id: _root_.scala.Array[Byte],
     |    @_root_.pbdirect.pbIndex(3) parent_span_id: _root_.scala.Array[Byte],
@@ -233,28 +233,28 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |    @_root_.pbdirect.pbIndex(16) resource: _root_.scala.Option[_root_.opencensus.proto.resource.v1.resource.Resource]
     |  )
     |  object Span {
-    |    @message final case class Tracestate(
+    |    final case class Tracestate(
     |      @_root_.pbdirect.pbIndex(1) entries: _root_.scala.List[_root_.opencensus.proto.trace.v1.trace.Span.Tracestate.Entry]
     |    )
     |    object Tracestate {
-    |      @message final case class Entry(
+    |      final case class Entry(
     |        @_root_.pbdirect.pbIndex(1) key: _root_.java.lang.String,
     |        @_root_.pbdirect.pbIndex(2) value: _root_.java.lang.String
     |      )
     |    }
-    |    @message final case class Attributes(
+    |    final case class Attributes(
     |      @_root_.pbdirect.pbIndex(1) attribute_map: _root_.scala.Predef.Map[_root_.java.lang.String, _root_.opencensus.proto.trace.v1.trace.AttributeValue],
     |      @_root_.pbdirect.pbIndex(2) dropped_attributes_count: _root_.scala.Int
     |    )
-    |    @message final case class TimeEvent(
+    |    final case class TimeEvent(
     |      @_root_.pbdirect.pbIndex(2, 3) value: _root_.scala.Option[_root_.scala.Either[_root_.opencensus.proto.trace.v1.trace.Span.TimeEvent.Annotation, _root_.opencensus.proto.trace.v1.trace.Span.TimeEvent.MessageEvent]]
     |    )
     |    object TimeEvent {
-    |      @message final case class Annotation(
+    |      final case class Annotation(
     |        @_root_.pbdirect.pbIndex(1) description: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString],
     |        @_root_.pbdirect.pbIndex(2) attributes: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.Span.Attributes]
     |      )
-    |      @message final case class MessageEvent(
+    |      final case class MessageEvent(
     |        @_root_.pbdirect.pbIndex(1) `type`: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.Span.TimeEvent.MessageEvent.Type],
     |        @_root_.pbdirect.pbIndex(2) id: _root_.shapeless.tag.@@[_root_.scala.Long, _root_.pbdirect.Unsigned],
     |        @_root_.pbdirect.pbIndex(3) uncompressed_size: _root_.shapeless.tag.@@[_root_.scala.Long, _root_.pbdirect.Unsigned],
@@ -270,12 +270,12 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |        }
     |      }
     |    }
-    |    @message final case class TimeEvents(
+    |    final case class TimeEvents(
     |      @_root_.pbdirect.pbIndex(1) time_event: _root_.scala.List[_root_.opencensus.proto.trace.v1.trace.Span.TimeEvent],
     |      @_root_.pbdirect.pbIndex(2) dropped_annotations_count: _root_.scala.Int,
     |      @_root_.pbdirect.pbIndex(3) dropped_message_events_count: _root_.scala.Int
     |    )
-    |    @message final case class Link(
+    |    final case class Link(
     |      @_root_.pbdirect.pbIndex(1) trace_id: _root_.scala.Array[Byte],
     |      @_root_.pbdirect.pbIndex(2) span_id: _root_.scala.Array[Byte],
     |      @_root_.pbdirect.pbIndex(3) `type`: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.Span.Link.Type],
@@ -290,7 +290,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |        val values = findValues
     |      }
     |    }
-    |    @message final case class Links(
+    |    final case class Links(
     |      @_root_.pbdirect.pbIndex(1) link: _root_.scala.List[_root_.opencensus.proto.trace.v1.trace.Span.Link],
     |      @_root_.pbdirect.pbIndex(2) dropped_links_count: _root_.scala.Int
     |    )
@@ -302,19 +302,19 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |      val values = findValues
     |    }
     |  }
-    |  @message final case class Status(
+    |  final case class Status(
     |    @_root_.pbdirect.pbIndex(1) code: _root_.scala.Int,
     |    @_root_.pbdirect.pbIndex(2) message: _root_.java.lang.String
     |  )
-    |  @message final case class AttributeValue(
+    |  final case class AttributeValue(
     |    @_root_.pbdirect.pbIndex(1, 2, 3, 4) value: _root_.scala.Option[_root_.shapeless.:+:[_root_.opencensus.proto.trace.v1.trace.TruncatableString, _root_.shapeless.:+:[_root_.scala.Long, _root_.shapeless.:+:[_root_.scala.Boolean, _root_.shapeless.:+:[_root_.scala.Double, _root_.shapeless.CNil]]]]]
     |  )
-    |  @message final case class StackTrace(
+    |  final case class StackTrace(
     |    @_root_.pbdirect.pbIndex(1) stack_frames: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.StackTrace.StackFrames],
     |    @_root_.pbdirect.pbIndex(2) stack_trace_hash_id: _root_.shapeless.tag.@@[_root_.scala.Long, _root_.pbdirect.Unsigned]
     |  )
     |  object StackTrace {
-    |    @message final case class StackFrame(
+    |    final case class StackFrame(
     |      @_root_.pbdirect.pbIndex(1) function_name: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString],
     |      @_root_.pbdirect.pbIndex(2) original_function_name: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString],
     |      @_root_.pbdirect.pbIndex(3) file_name: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString],
@@ -323,16 +323,16 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |      @_root_.pbdirect.pbIndex(6) load_module: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.Module],
     |      @_root_.pbdirect.pbIndex(7) source_version: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString]
     |    )
-    |    @message final case class StackFrames(
+    |    final case class StackFrames(
     |      @_root_.pbdirect.pbIndex(1) frame: _root_.scala.List[_root_.opencensus.proto.trace.v1.trace.StackTrace.StackFrame],
     |      @_root_.pbdirect.pbIndex(2) dropped_frames_count: _root_.scala.Int
     |    )
     |  }
-    |  @message final case class Module(
+    |  final case class Module(
     |    @_root_.pbdirect.pbIndex(1) module: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString],
     |    @_root_.pbdirect.pbIndex(2) build_id: _root_.scala.Option[_root_.opencensus.proto.trace.v1.trace.TruncatableString]
     |  )
-    |  @message final case class TruncatableString(
+    |  final case class TruncatableString(
     |    @_root_.pbdirect.pbIndex(1) value: _root_.java.lang.String,
     |    @_root_.pbdirect.pbIndex(2) truncated_byte_count: _root_.scala.Int
     |  )
@@ -354,7 +354,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
     |import _root_.higherkindness.mu.rpc.protocol._
     |
     |object integer_types {
-    |  @message final case class IntegerTypes(
+    |  final case class IntegerTypes(
     |    @_root_.pbdirect.pbIndex(1) a: _root_.scala.Int,
     |    @_root_.pbdirect.pbIndex(2) b: _root_.shapeless.tag.@@[_root_.scala.Int, _root_.pbdirect.Unsigned],
     |    @_root_.pbdirect.pbIndex(3) c: _root_.shapeless.tag.@@[_root_.scala.Int, _root_.pbdirect.Signed],


### PR DESCRIPTION
This annotation was only used for IDL generation, which we don't do anymore.

(also accidentally apply the formatter)