### PR TITLE
Release 0.0.21

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.0.21-SNAPSHOT"
+version in ThisBuild := "0.0.21"


### PR DESCRIPTION
This is so we can remove the `@message` annotation from mu-scala, as it's a relic of the IDL generation feature.