### PR TITLE
rollback incompatible cross imports

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/Protocol.scala
@@ -25,7 +25,7 @@ import org.apache.avro.{Schema, Protocol => AvroProtocol}
 import higherkindness.droste._
 import higherkindness.droste.syntax.all._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 final case class Protocol[A](
     name: String,

--- a/src/main/scala/higherkindness/skeuomorph/avro/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/avro/schema.scala
@@ -29,7 +29,7 @@ import org.apache.avro.Schema
 import org.apache.avro.Schema.Type
 import higherkindness.droste.{Algebra, Coalgebra}
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 @deriveTraverse sealed trait AvroF[A]
 object AvroF {

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/ParseProto.scala
@@ -33,7 +33,7 @@ import higherkindness.skeuomorph.{Parser, _}
 import higherkindness.droste._
 import higherkindness.droste.syntax.embed._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object ParseProto {
 

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
@@ -103,7 +103,7 @@ object ProtobufF {
       nestedMessages: List[A],
       nestedEnums: List[A]
   )                                                                                     extends ProtobufF[A]
-  final case class TFileDescriptor[A](values: List[A], name: String, `package`: Option[String]) extends ProtobufF[A]
+  final case class TFileDescriptor[A](values: List[A], name: String, `package`: String) extends ProtobufF[A]
 
   def `null`[A](): ProtobufF[A]                                                   = TNull()
   def double[A](): ProtobufF[A]                                                   = TDouble()

--- a/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
+++ b/src/main/scala/higherkindness/skeuomorph/protobuf/schema.scala
@@ -103,7 +103,7 @@ object ProtobufF {
       nestedMessages: List[A],
       nestedEnums: List[A]
   )                                                                                     extends ProtobufF[A]
-  final case class TFileDescriptor[A](values: List[A], name: String, `package`: String) extends ProtobufF[A]
+  final case class TFileDescriptor[A](values: List[A], name: String, `package`: Option[String]) extends ProtobufF[A]
 
   def `null`[A](): ProtobufF[A]                                                   = TNull()
   def double[A](): ProtobufF[A]                                                   = TDouble()

--- a/src/test/scala/higherkindness/skeuomorph/instances.scala
+++ b/src/test/scala/higherkindness/skeuomorph/instances.scala
@@ -29,7 +29,7 @@ import protobuf._
 import openapi._
 import openapi.schema.OpenApi
 import higherkindness.droste._
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 object instances {
   lazy val nonEmptyString: Gen[String] = Gen.alphaStr.filter(_.nonEmpty)

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -21,10 +21,12 @@ import higherkindness.skeuomorph.mu.MuF
 import higherkindness.skeuomorph.protobuf.ProtobufF._
 import higherkindness.skeuomorph.protobuf.ParseProto._
 import higherkindness.skeuomorph.mu.CompressionType
-import org.scalacheck.{Arbitrary, Gen}
+import org.scalacheck.{Arbitrary, Gen, Prop}
 import org.specs2.{ScalaCheck, Specification}
 import higherkindness.droste.data.Mu
 import higherkindness.droste.data.Mu._
+import org.specs2.scalacheck.ScalaCheckFunction2
+
 import scala.meta._
 import scala.meta.contrib._
 
@@ -56,7 +58,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
   The generated Scala code should escape 'type' keyword in package (directory) names. $codegenGoogleApi
   """
 
-  def codegenProtobufProtocol =
+  def codegenProtobufProtocol: ScalaCheckFunction2[CompressionType, Boolean, Prop] =
     prop { (ct: CompressionType, useIdiom: Boolean) =>
       val toMuProtocol: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] = {
         p: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol.fromProtobufProto(ct, useIdiom)(p)

--- a/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
+++ b/src/test/scala/higherkindness/skeuomorph/protobuf/ProtobufProtocolSpec.scala
@@ -21,11 +21,10 @@ import higherkindness.skeuomorph.mu.MuF
 import higherkindness.skeuomorph.protobuf.ProtobufF._
 import higherkindness.skeuomorph.protobuf.ParseProto._
 import higherkindness.skeuomorph.mu.CompressionType
-import org.scalacheck.{Arbitrary, Gen, Prop}
+import org.scalacheck.{Arbitrary, Gen}
 import org.specs2.{ScalaCheck, Specification}
 import higherkindness.droste.data.Mu
 import higherkindness.droste.data.Mu._
-import org.specs2.scalacheck.ScalaCheckFunction2
 
 import scala.meta._
 import scala.meta.contrib._
@@ -58,7 +57,7 @@ class ProtobufProtocolSpec extends Specification with ScalaCheck {
   The generated Scala code should escape 'type' keyword in package (directory) names. $codegenGoogleApi
   """
 
-  def codegenProtobufProtocol: ScalaCheckFunction2[CompressionType, Boolean, Prop] =
+  def codegenProtobufProtocol =
     prop { (ct: CompressionType, useIdiom: Boolean) =>
       val toMuProtocol: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol[Mu[MuF]] = {
         p: Protocol[Mu[ProtobufF]] => higherkindness.skeuomorph.mu.Protocol.fromProtobufProto(ct, useIdiom)(p)


### PR DESCRIPTION
I accidentally included an import in https://github.com/higherkindness/skeuomorph/pull/321 that doesn't compile correctly in scala 2.12.  My bad.  This change should fix that.