### PR TITLE
Restores the cats implicits import

### DIFF
--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/circe/package.scala
@@ -38,7 +38,7 @@ package object circe {
     List("io.circe._", "io.circe.generic.semiauto._").map(PackageName.apply) ++ http4sPackages
 
   private val enumPackages = http4sPackages ++
-    List("cats._", "cats.syntax.all._", "io.circe._").map(PackageName.apply)
+    List("cats._", "cats.implicits._", "io.circe._").map(PackageName.apply)
 
   private def codecsTypes[T](name: String): ((String, Tpe[T]), (String, Tpe[T])) = {
     val tpe = Tpe[T](name)

--- a/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
+++ b/src/main/scala/higherkindness/skeuomorph/openapi/client/http4s/print.scala
@@ -247,7 +247,7 @@ object print {
   private val packages = List(
     "cats._",
     "cats.effect._",
-    "cats.syntax.all._",
+    "cats.implicits._",
     "io.circe._",
     "org.http4s._",
     "org.http4s.client.Client",

--- a/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
+++ b/src/test/scala/higherkindness/skeuomorph/openapi/OpenApiPrintSpecification.scala
@@ -129,7 +129,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |  import cats.Applicative
             |  import cats.effect.Sync
             |  import cats._
-            |  import cats.syntax.all._
+            |  import cats.implicits._
             |  import io.circe._
             |  implicit val ColorShow: Show[Color] = Show.show {
             |  case Blue => "Blue"
@@ -166,7 +166,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
              |  import cats.Applicative
              |  import cats.effect.Sync
              |  import cats._
-             |  import cats.syntax.all._
+             |  import cats.implicits._
              |  import io.circe._
              |  implicit val SomethingForShow: Show[`something-For`] = Show.show {
              |  case `xo-m` => "xo-m"
@@ -207,7 +207,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |  import cats.Applicative
             |  import cats.effect.Sync
             |  import cats._
-            |  import cats.syntax.all._
+            |  import cats.implicits._
             |  import io.circe._
             |  implicit val PetEncoder: Encoder[Pet] = Encoder.instance { x =>
             |import shapeless.Poly1
@@ -247,7 +247,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
             |  import cats.Applicative
             |  import cats.effect.Sync
             |  import cats._
-            |  import cats.syntax.all._
+            |  import cats.implicits._
             |  import io.circe._
             |  implicit val Pet1Encoder: Encoder[`1-Pet`] = Encoder.instance { x =>
             |import shapeless.Poly1
@@ -407,7 +407,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
            |  import cats.Applicative
            |  import cats.effect.Sync
            |  import cats._
-           |  import cats.syntax.all._
+           |  import cats.implicits._
            |  import io.circe._
            |  implicit val StatusShow: Show[status] = Show.show {
            |  case Pending => "Pending"
@@ -1048,7 +1048,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       ) must ===(
         s"""|import cats._
             |import cats.effect._
-            |import cats.syntax.all._
+            |import cats.implicits._
             |import io.circe._
             |import org.http4s._
             |import org.http4s.client.Client
@@ -1086,7 +1086,7 @@ class OpenApiPrintSpecification extends org.specs2.mutable.Specification {
       impl.print(PackageName("petstore") -> petstoreOpenApi.withPath(mediaTypeReferences)) must ===(
         s"""|import cats._
         |import cats.effect._
-        |import cats.syntax.all._
+        |import cats.implicits._
         |import io.circe._
         |import org.http4s._
         |import org.http4s.client.Client


### PR DESCRIPTION
This is needed since we need some implicit instances (like `Show[A]`) and not only syntax.